### PR TITLE
Configurability

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -2007,7 +2007,7 @@ struct
     let new_cpa = CPA.add_list_fun reachable (fun v -> CPA.find v st.cpa) new_cpa in
 
     (* Projection to Precision of the Callee *)
-    let p = PU.precision_from_fundec fundec in
+    let p = PU.int_precision_from_fundec fundec in
     let new_cpa = project (Some p) new_cpa in
 
     (* Identify locals of this fundec for which an outer copy (from a call down the callstack) is reachable *)
@@ -2448,7 +2448,7 @@ struct
       let nst = add_globals st fun_st in
 
       (* Projection to Precision of the Caller *)
-      let p = PrecisionUtil.precision_from_node () in (* Since f is the fundec of the Callee we have to get the fundec of the current Node instead *)
+      let p = PrecisionUtil.int_precision_from_node () in (* Since f is the fundec of the Callee we have to get the fundec of the current Node instead *)
       let return_val = project_val (Some p) return_val (is_privglob (return_varinfo ())) in
       let cpa' = project (Some p) nst.cpa in
 

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -1,4 +1,3 @@
-open GobConfig
 open Pretty
 open PrecisionUtil
 
@@ -164,14 +163,14 @@ module FloatInterval = struct
   let ne = eval_int_binop ne
 end
 
-module FloatDomImpl = struct
+module FloatDomTupleImpl = struct
   include Printable.Std (* for default invariant, tag, ... *)
   module F1 = FloatInterval
   open Batteries
 
   type t = F1.t option [@@deriving to_yojson, eq, ord]
 
-  let name () = "FloatInterval"
+  let name () = "floatdomtuple"
 
   type 'a m = (module FloatDomainBase with type t = 'a)
   (* only first-order polymorphism on functions 

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -1,4 +1,42 @@
+open GobConfig
 open Pretty
+open PrecisionUtil
+
+module type FloatArith = sig
+  type t
+
+  val neg : t -> t
+  (** Negating an flaot value: [-x] *)
+  val add : t -> t -> t
+  (** Addition: [x + y] *)
+  val sub : t -> t -> t
+  (** Subtraction: [x - y] *)
+  val mul : t -> t -> t
+  (** Multiplication: [x * y] *)
+  val div : t -> t -> t
+  (** Division: [x / y] *)
+
+  (** {b Comparison operators} *)
+  val lt : t -> t -> IntDomain.IntDomTuple.t
+  (** Less than: [x < y] *)
+  val gt : t -> t -> IntDomain.IntDomTuple.t
+  (** Greater than: [x > y] *)
+  val le : t -> t -> IntDomain.IntDomTuple.t
+  (** Less than or equal: [x <= y] *)
+  val ge : t -> t -> IntDomain.IntDomTuple.t
+  (** Greater than or equal: [x >= y] *)
+  val eq : t -> t -> IntDomain.IntDomTuple.t
+  (** Equal to: [x == y] *)
+  val ne : t -> t -> IntDomain.IntDomTuple.t
+  (** Not equal to: [x != y] *)
+end
+
+module type FloatDomainBase = sig
+  include Lattice.S
+  include FloatArith with type t := t
+
+  val of_const : float -> t
+end
 
 let eval_binop operation op1 op2 =
   match (op1, op2) with Some v1, Some v2 -> operation v1 v2 | _ -> None
@@ -11,7 +49,6 @@ let eval_int_binop operation op1 op2 =
     (Big_int_Z.big_int_of_int a, Big_int_Z.big_int_of_int b)
 
 let add (low1, high1) (low2, high2) = Some (low1 +. low2, high1 +. high2)
-
 let sub (low1, high1) (low2, high2) = Some (low1 -. low2, high1 -. high2)
 
 let mul (low1, high1) (low2, high2) =
@@ -54,16 +91,13 @@ module FloatDomTuple = struct
   type t = (float * float) option [@@deriving eq, to_yojson]
 
   let of_const f = Some (f, f)
-
   let hash = Hashtbl.hash
-
   let compare _ _ = failwith "todo"
 
   let show = function
-    | None ->
-        "Float [arbitrary]"
+    | None -> "Float [arbitrary]"
     | Some (low, high) ->
-        "Float [" ^ string_of_float low ^ "," ^ string_of_float high ^ "]"
+      "Float [" ^ string_of_float low ^ "," ^ string_of_float high ^ "]"
 
   let pretty () x = text (show x)
 
@@ -71,19 +105,12 @@ module FloatDomTuple = struct
     BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (show x)
 
   let name () = "float interval domain"
-
   let invariant _ (x : t) = failwith "todo"
-
   let tag (x : t) = failwith "todo"
-
   let arbitrary () = failwith "todo"
-
   let relift (x : t) = failwith "todo"
-
   let leq _ _ = failwith "todo"
-
   let join _ _ = failwith "todo"
-
   let meet _ _ = failwith "todo"
 
   (** [widen x y] assumes [leq x y]. Solvers guarantee this by calling [widen old (join old new)]. *)
@@ -96,32 +123,138 @@ module FloatDomTuple = struct
     Pretty.dprintf "%a instead of %a" pretty x pretty y
 
   let bot () = failwith "no bot exists"
-
   let is_bot _ = failwith "no bot exists"
-
   let top () = None
-
   let is_top = Option.is_none
-
   let neg = Option.map (fun (low, high) -> (-.high, -.low))
-
   let add = eval_binop add
-
   let sub = eval_binop sub
-
   let mul = eval_binop mul
-
   let div = eval_binop div
-
   let lt = eval_int_binop lt
-
   let gt = eval_int_binop gt
-
   let le _ _ = failwith "todo - le"
-
   let ge _ _ = failwith "todo - ge"
-
   let eq = eval_int_binop eq
-
   let ne = eval_int_binop ne
+end
+
+module FloatDomainImpl = struct
+  include Printable.Std (* for default invariant, tag, ... *)
+  module F1 = FloatDomTuple
+  open Batteries
+
+  type t = F1.t option [@@deriving to_yojson, eq, ord]
+
+  let name () = "floatdomtuple"
+
+  type 'a m = (module FloatDomainBase with type t = 'a)
+  (* only first-order polymorphism on functions 
+     -> use records to get around monomorphism restriction on arguments (Same trick as used in intDomain) *)
+  type 'b poly_in = { fi : 'a. 'a m -> 'b -> 'a }
+  type 'b poly_pr = { fp : 'a. 'a m -> 'a -> 'b }
+  type 'b poly2_pr = { f2p : 'a. 'a m -> 'a -> 'a -> 'b }
+  type poly1 = { f1 : 'a. 'a m -> 'a -> 'a }
+  type poly2 = { f2 : 'a. 'a m -> 'a -> 'a -> 'a }
+
+  let create r x (f1 : float_precision) =
+    let f b g = if b then Some (g x) else None in
+    f f1 @@ r.fi (module F1)
+
+  let create r x =
+    (* use where values are introduced *)
+    create r x (float_precision_from_node_or_config ())
+
+  let opt_map2 f =
+    curry @@ function Some x, Some y -> Some (f x y) | _ -> None
+
+  let exists = function Some true -> true | _ -> false
+  let for_all = function Some false -> false | _ -> true
+
+  let mapp r = BatOption.map (r.fp (module F1))
+
+  let map r a = BatOption.(map (r.f1 (module F1)) a)
+  let map2 r xa ya = opt_map2 (r.f2 (module F1)) xa ya
+  let map2p r xa ya = opt_map2 (r.f2p (module F1)) xa ya
+
+  let map2int r xa ya =
+    Option.map_default identity
+      (IntDomain.IntDomTuple.top_of IBool) (opt_map2 (r.f2p (module F1)) xa ya)
+
+  let ( %% ) f g x = f % g x
+
+  let show x =
+    Option.map_default identity ""
+      (mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) x -> F.name () ^ ":" ^ F.show x); } x)
+
+  let to_yojson =
+    [%to_yojson: Yojson.Safe.t option]
+    % mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.to_yojson); }
+  let hash x =
+    Option.map_default identity 0
+      (mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.hash); } x)
+
+  let of_const =
+    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.of_const); }
+
+  let top =
+    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.top); }
+  let bot =
+    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.bot); }
+  let is_bot =
+    exists
+    % mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.is_bot); }
+  let is_top =
+    for_all
+    % mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.is_top); }
+
+
+  let leq =
+    for_all
+    %% map2p { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.leq); }
+
+  let pretty () x =
+    Option.map_default identity nil
+      (mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.pretty ()); } x)
+
+  (* f1: one and only unary op *)
+  let neg =
+    map { f1= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.neg); }
+
+  (* f2: binary ops *)
+  let join =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.join); }
+  let meet =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.meet); }
+  let widen =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.widen); }
+  let narrow =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.narrow); }
+  let add =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.add); }
+  let sub =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.sub); }
+  let mul =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.mul); }
+  let div =
+    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.div); }
+
+  (* f2: binary ops which return an integer *)
+  let lt =
+    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.lt); }
+  let gt =
+    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.gt); }
+  let le =
+    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.le); }
+  let ge =
+    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.ge); }
+  let eq =
+    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.eq); }
+  let ne =
+    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.ne); }
+
+  let pretty_diff () (x, y) = dprintf "%a instead of %a" pretty x pretty y
+
+  let printXml f x =
+    BatPrintf.fprintf f "<value>\n<data>\n%s\n</data>\n</value>\n" (show x)
 end

--- a/src/cdomains/floatDomain.mli
+++ b/src/cdomains/floatDomain.mli
@@ -38,6 +38,6 @@ module type FloatDomainBase = sig
   val of_const : float -> t
 end
 
-module FloatDomainImpl : sig
+module FloatDomImpl : sig
   include FloatDomainBase
 end

--- a/src/cdomains/floatDomain.mli
+++ b/src/cdomains/floatDomain.mli
@@ -1,44 +1,43 @@
 (** Abstract Domains for floats. These are domains that support the C
   * operations on double/float values. *)
 
-  module FloatDomTuple : sig
-    include Lattice.S
+module type FloatArith = sig
+  type t
 
-    val of_const: float -> t
+  val neg : t -> t
+  (** Negating an flaot value: [-x] *)
+  val add : t -> t -> t
+  (** Addition: [x + y] *)
+  val sub : t -> t -> t
+  (** Subtraction: [x - y] *)
+  val mul : t -> t -> t
+  (** Multiplication: [x * y] *)
+  val div : t -> t -> t
+  (** Division: [x / y] *)
 
-    val neg: t -> t
-    (** Negating an flaot value: [-x] *)
-  
-    val add: t -> t -> t
-    (** Addition: [x + y] *)
-  
-    val sub: t -> t -> t
-    (** Subtraction: [x - y] *)
-  
-    val mul: t -> t -> t
-    (** Multiplication: [x * y] *)
-  
-    val div: t -> t -> t
-    (** Division: [x / y] *)  
-  
-    (** {b Comparison operators} *)
-  
-    val lt: t -> t -> IntDomain.IntDomTuple.t
-    (** Less than: [x < y] *)
-  
-    val gt: t -> t -> IntDomain.IntDomTuple.t
-    (** Greater than: [x > y] *)
-  
-    val le: t -> t -> IntDomain.IntDomTuple.t
-    (** Less than or equal: [x <= y] *)
-  
-    val ge: t -> t -> IntDomain.IntDomTuple.t
-    (** Greater than or equal: [x >= y] *)
-  
-    val eq: t -> t -> IntDomain.IntDomTuple.t
-    (** Equal to: [x == y] *)
-  
-    val ne: t -> t -> IntDomain.IntDomTuple.t
-    (** Not equal to: [x != y] *)
-  end
+  (** {b Comparison operators} *)
+  val lt : t -> t -> IntDomain.IntDomTuple.t
+  (** Less than: [x < y] *)
+  val gt : t -> t -> IntDomain.IntDomTuple.t
+  (** Greater than: [x > y] *)
+  val le : t -> t -> IntDomain.IntDomTuple.t
+  (** Less than or equal: [x <= y] *)
+  val ge : t -> t -> IntDomain.IntDomTuple.t
+  (** Greater than or equal: [x >= y] *)
+  val eq : t -> t -> IntDomain.IntDomTuple.t
+  (** Equal to: [x == y] *)
+  val ne : t -> t -> IntDomain.IntDomTuple.t
+  (** Not equal to: [x != y] *)
+end
 
+module type FloatDomainBase = sig
+  include Lattice.S
+
+  include FloatArith with type t := t
+
+  val of_const : float -> t
+end
+
+module FloatDomainImpl : sig
+  include FloatDomainBase
+end

--- a/src/cdomains/floatDomain.mli
+++ b/src/cdomains/floatDomain.mli
@@ -38,6 +38,6 @@ module type FloatDomainBase = sig
   val of_const : float -> t
 end
 
-module FloatDomImpl : sig
+module FloatDomTupleImpl : sig
   include FloatDomainBase
 end

--- a/src/cdomains/intDomain.ml
+++ b/src/cdomains/intDomain.ml
@@ -162,7 +162,7 @@ sig
   val refine_with_excl_list: Cil.ikind -> t -> (int_t list * (int64 * int64)) option -> t
   val refine_with_incl_list: Cil.ikind -> t -> int_t list option -> t
 
-  val project: Cil.ikind -> precision -> t -> t
+  val project: Cil.ikind -> int_precision -> t -> t
   val arbitrary: Cil.ikind -> t QCheck.arbitrary
 end
 (** Interface of IntDomain implementations taking an ikind for arithmetic operations *)
@@ -181,7 +181,7 @@ sig
   val ending     : Cil.ikind -> int_t -> t
   val is_top_of: Cil.ikind -> t -> bool
 
-  val project: precision -> t -> t
+  val project: int_precision -> t -> t
 end
 
 module type Z = Y with type int_t = BI.t
@@ -2529,16 +2529,16 @@ module IntDomTupleImpl = struct
   type poly1 = {f1: 'a. 'a m -> ?no_ov:bool -> 'a -> 'a} (* needed b/c above 'b must be different from 'a *)
   type poly2 = {f2: 'a. 'a m -> ?no_ov:bool -> 'a -> 'a -> 'a}
   type 'b poly3 = { f3: 'a. 'a m -> 'a option } (* used for projection to given precision *)
-  let create r x ((p1, p2, p3, p4): precision) =
+  let create r x ((p1, p2, p3, p4): int_precision) =
     let f b g = if b then Some (g x) else None in
     f p1 @@ r.fi (module I1), f p2 @@ r.fi (module I2), f p3 @@ r.fi (module I3), f p4 @@ r.fi (module I4)
   let create r x = (* use where values are introduced *)
-    create r x (precision_from_node_or_config ())
-  let create2 r x ((p1, p2, p3, p4): precision) =
+    create r x (int_precision_from_node_or_config ())
+  let create2 r x ((p1, p2, p3, p4): int_precision) =
     let f b g = if b then Some (g x) else None in
     f p1 @@ r.fi2 (module I1), f p2 @@ r.fi2 (module I2), f p3 @@ r.fi2 (module I3), f p4 @@ r.fi2 (module I4)
   let create2 r x = (* use where values are introduced *)
-    create2 r x (precision_from_node_or_config ())
+    create2 r x (int_precision_from_node_or_config ())
 
   let opt_map2 f ?no_ov =
     curry @@ function Some x, Some y -> Some (f ?no_ov x y) | _ -> None
@@ -2806,7 +2806,7 @@ module IntDomTupleImpl = struct
    * ~keep:true will keep elements that are `Some x` but should be set to `None` by p.
    *  This way we won't loose any information for the refinement.
    * ~keep:false will set the elements to `None` as defined by p *)
-  let project ik (p: precision) t =
+  let project ik (p: int_precision) t =
     let t_padded = map ~keep:true { f3 = fun (type a) (module I:S with type t = a) -> Some (I.top_of ik) } t p in
     let t_refined = refine ik t_padded in
     map ~keep:false { f3 = fun (type a) (module I:S with type t = a) -> None } t_refined p

--- a/src/cdomains/intDomain.mli
+++ b/src/cdomains/intDomain.mli
@@ -274,7 +274,7 @@ sig
   val refine_with_excl_list: Cil.ikind -> t -> (int_t list * (int64 * int64)) option -> t
   val refine_with_incl_list: Cil.ikind -> t -> int_t list option -> t
 
-  val project: Cil.ikind -> PrecisionUtil.precision -> t -> t
+  val project: Cil.ikind -> PrecisionUtil.int_precision -> t -> t
   val arbitrary: Cil.ikind -> t QCheck.arbitrary
 end
 (** Interface of IntDomain implementations taking an ikind for arithmetic operations *)
@@ -303,7 +303,7 @@ sig
 
   val is_top_of: Cil.ikind -> t -> bool
 
-  val project: PrecisionUtil.precision -> t -> t
+  val project: PrecisionUtil.int_precision -> t -> t
 end
 (** The signature of integral value domains keeping track of ikind information *)
 

--- a/src/cdomains/preValueDomain.ml
+++ b/src/cdomains/preValueDomain.ml
@@ -1,5 +1,5 @@
 module ID = IntDomain.IntDomTuple
-module FD = FloatDomain.FloatDomImpl
+module FD = FloatDomain.FloatDomTupleImpl
 module IndexDomain = IntDomain.IntDomWithDefaultIkind (ID) (IntDomain.PtrDiffIkind)
 module AD = AddressDomain.AddressSet (IndexDomain)
 module Addr = Lval.NormalLat (IndexDomain)

--- a/src/cdomains/preValueDomain.ml
+++ b/src/cdomains/preValueDomain.ml
@@ -1,5 +1,5 @@
 module ID = IntDomain.IntDomTuple
-module FD = FloatDomain.FloatDomainImpl
+module FD = FloatDomain.FloatDomImpl
 module IndexDomain = IntDomain.IntDomWithDefaultIkind (ID) (IntDomain.PtrDiffIkind)
 module AD = AddressDomain.AddressSet (IndexDomain)
 module Addr = Lval.NormalLat (IndexDomain)

--- a/src/cdomains/preValueDomain.ml
+++ b/src/cdomains/preValueDomain.ml
@@ -1,5 +1,5 @@
 module ID = IntDomain.IntDomTuple
-module FD = FloatDomain.FloatDomTuple
+module FD = FloatDomain.FloatDomainImpl
 module IndexDomain = IntDomain.IntDomWithDefaultIkind (ID) (IntDomain.PtrDiffIkind)
 module AD = AddressDomain.AddressSet (IndexDomain)
 module Addr = Lval.NormalLat (IndexDomain)

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -36,7 +36,7 @@ sig
   val is_top_value: t -> typ -> bool
   val zero_init_value: typ -> t
 
-  val project: precision -> t -> t
+  val project: int_precision -> t -> t
 end
 
 module type Blob =

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -511,6 +511,20 @@
           },
           "additionalProperties": false
         },
+        "float": {
+          "title": "ana.float",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "title": "ana.float.interval",
+              "description":
+                "Use FloatDomain: (float * float) option.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
         "file": {
           "title": "ana.file",
           "type": "object",

--- a/src/util/precisionUtil.ml
+++ b/src/util/precisionUtil.ml
@@ -1,23 +1,31 @@
 (* We define precision by the number of IntDomains activated.
  * We currently have 4 types: DefExc, Interval, Enums, Congruence *)
-type precision = (bool * bool * bool * bool)
+type int_precision = (bool * bool * bool * bool)
+(* Same applies for FloatDomain
+ * We currently have only an interval type analysis *)
+type float_precision = (bool)
 
 
 (* Thus for maximum precision we activate all IntDomains *)
-let max_precision : precision = (true, true, true, true)
-let precision_from_fundec (fd: Cil.fundec): precision =
+let max_precision : int_precision = (true, true, true, true)
+let precision_from_fundec (fd: Cil.fundec): int_precision =
   ((ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.def_exc" ~removeAttr:"no-def_exc" ~keepAttr:"def_exc" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.interval" ~removeAttr:"no-interval" ~keepAttr:"interval" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.enums" ~removeAttr:"no-enums" ~keepAttr:"enums" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.congruence" ~removeAttr:"no-congruence" ~keepAttr:"congruence" fd))
-let precision_from_node (): precision =
+let precision_from_node (): int_precision =
   match !MyCFG.current_node with
   | Some n -> precision_from_fundec (Node.find_fundec n)
   | _ -> max_precision (* In case a Node is None we have to handle Globals, i.e. we activate all IntDomains (TODO: verify this assumption) *)
 
-let precision_from_node_or_config (): precision =
+let int_precision_from_node_or_config (): int_precision =
   if GobConfig.get_bool "annotation.int.enabled" then
     precision_from_node ()
   else
     let f n = GobConfig.get_bool ("ana.int."^n) in
     (f "def_exc", f "interval", f "enums", f "congruence")
+
+let float_precision_from_node_or_config (): float_precision =
+  (* TODO(Practical2022): allow partital evaluation by enabling/disabling our analysis on a more finegrained level *)
+  let f n = GobConfig.get_bool ("ana.float."^n) in
+  (f "interval")

--- a/src/util/precisionUtil.ml
+++ b/src/util/precisionUtil.ml
@@ -8,24 +8,24 @@ type float_precision = (bool)
 
 (* Thus for maximum precision we activate all IntDomains *)
 let max_precision : int_precision = (true, true, true, true)
-let precision_from_fundec (fd: Cil.fundec): int_precision =
+let int_precision_from_fundec (fd: Cil.fundec): int_precision =
   ((ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.def_exc" ~removeAttr:"no-def_exc" ~keepAttr:"def_exc" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.interval" ~removeAttr:"no-interval" ~keepAttr:"interval" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.enums" ~removeAttr:"no-enums" ~keepAttr:"enums" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.congruence" ~removeAttr:"no-congruence" ~keepAttr:"congruence" fd))
-let precision_from_node (): int_precision =
+let int_precision_from_node (): int_precision =
   match !MyCFG.current_node with
-  | Some n -> precision_from_fundec (Node.find_fundec n)
+  | Some n -> int_precision_from_fundec (Node.find_fundec n)
   | _ -> max_precision (* In case a Node is None we have to handle Globals, i.e. we activate all IntDomains (TODO: verify this assumption) *)
 
 let int_precision_from_node_or_config (): int_precision =
   if GobConfig.get_bool "annotation.int.enabled" then
-    precision_from_node ()
+    int_precision_from_node ()
   else
     let f n = GobConfig.get_bool ("ana.int."^n) in
     (f "def_exc", f "interval", f "enums", f "congruence")
 
-let float_precision_from_node_or_config (): float_precision =
+let float_precision_from_config (): float_precision =
   (* TODO(Practical2022): allow partital evaluation by enabling/disabling our analysis on a more finegrained level *)
   let f n = GobConfig.get_bool ("ana.float."^n) in
   (f "interval")

--- a/tests/regression/56-floats/01-base.c
+++ b/tests/regression/56-floats/01-base.c
@@ -1,3 +1,4 @@
+// PARAM: --enable ana.float.interval
 #include <assert.h>
 #include <float.h>
 #include <limits.h>


### PR DESCRIPTION
This adds the option `ana.float.interval`for enabling/disabling our floating point analysis (disabled by default). This also means, that all our regression tests must start with `// PARAM: --enable ana.float.interval`.

Further configuration options (e.g. about precision) can be added by 
 - inserting them into the `src/util/options.schema.json`
 - and accessing them in code with a call to `GobConfig.get_bool "ana.float...."` (examples in `intDomain.ml`)
 
This also adds a new `FloatDomainImpl` which wraps our actual domain implementation module `FloatDomTuple` (probably their names should be swapped at some point in time). For now, this is more or less only overhead and the only real functionality, which this setup provides, is the ability to enable/disable or analysis. However, it is very important for further extensions to the float analysis in general (e.g. adding a different float domain in the future) and resembles the structure used in the int domain.