### PR TITLE
Provide cast support between int types and double

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -137,7 +137,7 @@ struct
   (* Evaluating Cil's unary operators. *)
   let evalunop op typ = function
     | `Int v1 -> `Int (ID.cast_to (Cilfacade.get_ikind typ) (unop_ID op v1))
-    | `Float v -> `Float (unop_FD op v) (* TODO(Practical2022): Do we require a type check? *)
+    | `Float v -> `Float (unop_FD op v)
     | `Address a when op = LNot ->
       if AD.is_null a then
         `Int (ID.of_bool (Cilfacade.get_ikind typ) true)
@@ -727,7 +727,7 @@ struct
       | Const (CInt (num,ikind,str)) ->
         (match str with Some x -> M.tracel "casto" "CInt (%s, %a, %s)\n" (Cilint.string_of_cilint num) d_ikind ikind x | None -> ());
         `Int (ID.cast_to ikind (IntDomain.of_const (num,ikind,str)))
-      | Const (CReal (num, _, _)) -> `Float (FD.of_const num) (* TODO(Practical(2022): use string representation instead *)
+      | Const (CReal (num, FDouble, _)) -> `Float (FD.of_const num) (* TODO(Practical(2022): use string representation instead, extend to other floating point types *)
       (* String literals *)
       | Const (CStr (x,_)) -> `Address (AD.from_string x) (* normal 8-bit strings, type: char* *)
       | Const (CWStr (xs,_) as c) -> (* wide character strings, type: wchar_t* *)

--- a/src/cdomains/floatDomain.mli
+++ b/src/cdomains/floatDomain.mli
@@ -53,10 +53,11 @@ end
 
 module type FloatDomainBase = sig
   include Lattice.S
-
   include FloatArith with type t := t
 
   val of_const : float -> t
+  val of_int : IntDomain.IntDomTuple.t -> t
+  val cast_to : Cil.ikind -> t -> IntDomain.IntDomTuple.t
 end
 
 module FloatDomTupleImpl : sig

--- a/tests/regression/56-floats/04-casts.c
+++ b/tests/regression/56-floats/04-casts.c
@@ -1,0 +1,59 @@
+// PARAM: --enable ana.int.interval --enable ana.float.interval
+#include <assert.h>
+
+#define RANGE(val, min, max) \
+    if (rnd)                 \
+    {                        \
+        val = min;           \
+    }                        \
+    else                     \
+    {                        \
+        val = max;           \
+    }
+
+int main()
+{
+    // Casts from double into different variants of ints
+    assert((int)0.0);      // FAIL!
+    assert((long)0.0);     // FAIL!
+    assert((unsigned)0.0); // FAIL!
+
+    assert((unsigned)1.0); // SUCCESS!
+    assert((long)2.0);     // SUCCESS!
+    assert((int)3.0);      // SUCCESS!
+
+    // Cast from int into double
+    assert((double)0);  // FAIL!
+    assert((double)0l); // FAIL!
+    assert((double)0u); // FAIL!
+
+    assert((double)1u); // SUCCESS!
+    assert((double)2l); // SUCCESS!
+    assert((double)3);  // SUCCESS!
+
+    // cast with ranges
+    int rnd;
+
+    double value;
+    int i;
+    long l;
+    unsigned u;
+
+    RANGE(i, -5, 5);
+    value = (double)i;
+    assert(-5. <= value && value <= 5.); // SUCCESS!
+
+    RANGE(l, 10, 20);
+    value = l;
+    assert(10. <= value && value <= 20.); // SUCCESS!
+
+    RANGE(u, 100, 1000);
+    value = u;
+    assert(value > 1.); // SUCCESS!
+
+    RANGE(value, -10., 10.);
+    i = (int)value;
+    assert(-10 <= i && i <= 10); // SUCCESS!
+
+    return 0;
+}


### PR DESCRIPTION
This add support for casting between int types and doubles
- Double to int is defined as truncate towards zero and therefore possible without rounding
- Int to double requires some rounding. Here i use the trick to cast the BigInt into float and back to see whether is is representable as float.

Also adds explicitly checks for `FDouble` type in some locations and removes it the comments on type checks in others, where the checks should be rather be handled inside the `FloatDomTuple` once we support multiple different fkinds.