### PR TITLE
Add node-level configurability of float analysis

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -85,7 +85,7 @@ struct
 
   let project_val p_opt value is_glob =
     match GobConfig.get_bool "annotation.int.enabled", is_glob, p_opt with
-    | true, true, _ -> VD.project PU.max_precision value
+    | true, true, _ -> VD.project PU.max_int_precision value
     | true, false, Some p -> VD.project p value
     | _ -> value
 

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -187,7 +187,7 @@ module FloatDomTupleImpl = struct
 
   let create r x =
     (* use where values are introduced *)
-    create r x (float_precision_from_config ())
+    create r x (float_precision_from_node_or_config ())
 
   let opt_map2 f =
     curry @@ function Some x, Some y -> Some (f x y) | _ -> None

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1229,6 +1229,20 @@
           },
           "additionalProperties": false
         },
+        "float": {
+          "title": "annotation.float",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "annotation.float.enabled",
+              "description":
+                "Enable manual annotation of functions with desired precision, i.e. the activated FloatDomains.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
         "goblint_context": {
           "title": "annotation.goblint_context",
           "type": "object",

--- a/src/util/precisionUtil.ml
+++ b/src/util/precisionUtil.ml
@@ -6,17 +6,26 @@ type int_precision = (bool * bool * bool * bool)
 type float_precision = (bool)
 
 
-(* Thus for maximum precision we activate all IntDomains *)
-let max_precision : int_precision = (true, true, true, true)
+(* Thus for maximum precision we activate all Domains *)
+let max_int_precision : int_precision = (true, true, true, true)
+let max_float_precision : float_precision = (true)
 let int_precision_from_fundec (fd: Cil.fundec): int_precision =
   ((ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.def_exc" ~removeAttr:"no-def_exc" ~keepAttr:"def_exc" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.interval" ~removeAttr:"no-interval" ~keepAttr:"interval" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.enums" ~removeAttr:"no-enums" ~keepAttr:"enums" fd),
    (ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.int.congruence" ~removeAttr:"no-congruence" ~keepAttr:"congruence" fd))
+
+  let float_precision_from_fundec (fd: Cil.fundec): float_precision =
+  ((ContextUtil.should_keep ~isAttr:GobPrecision ~keepOption:"ana.float.interval" ~removeAttr:"no-float-interval" ~keepAttr:"float-interval" fd))
 let int_precision_from_node (): int_precision =
   match !MyCFG.current_node with
   | Some n -> int_precision_from_fundec (Node.find_fundec n)
-  | _ -> max_precision (* In case a Node is None we have to handle Globals, i.e. we activate all IntDomains (TODO: verify this assumption) *)
+  | _ -> max_int_precision (* In case a Node is None we have to handle Globals, i.e. we activate all IntDomains (TODO: verify this assumption) *)
+
+  let float_precision_from_node (): float_precision =
+    match !MyCFG.current_node with
+    | Some n -> float_precision_from_fundec (Node.find_fundec n)
+    | _ -> max_float_precision
 
 let int_precision_from_node_or_config (): int_precision =
   if GobConfig.get_bool "annotation.int.enabled" then
@@ -25,7 +34,9 @@ let int_precision_from_node_or_config (): int_precision =
     let f n = GobConfig.get_bool ("ana.int."^n) in
     (f "def_exc", f "interval", f "enums", f "congruence")
 
-let float_precision_from_config (): float_precision =
-  (* TODO(Practical2022): allow partital evaluation by enabling/disabling our analysis on a more finegrained level *)
-  let f n = GobConfig.get_bool ("ana.float."^n) in
-  (f "interval")
+let float_precision_from_node_or_config (): float_precision =
+  if GobConfig.get_bool "annotation.float.enabled" then
+    float_precision_from_node ()
+  else
+    let f n = GobConfig.get_bool ("ana.float."^n) in
+    (f "interval")

--- a/tests/regression/56-floats/02-node_configuration.c
+++ b/tests/regression/56-floats/02-node_configuration.c
@@ -1,0 +1,19 @@
+// PARAM: --enable annotation.float.enabled
+#include <assert.h>
+
+int main() __attribute__((goblint_precision("no-float-interval")));
+void test() __attribute__((goblint_precision("float-interval")));
+
+int main()
+{
+    double a = 2.;
+    assert(a == 2.); // UNKNOWN!
+    test();
+    return 0;
+}
+
+void test()
+{
+    double b = 2.;
+    assert(b == 2.); // SUCCESS!
+}


### PR DESCRIPTION
This adds another way of enabling/disabling our analysis on a more fine-grained level. With function annotations, you can now configure it on a node level (per function, example in regtest 56/2).

I decided to go with the configuration parameters `no-float-interval` and `float_interval` as `interval` and `no-interval` are already used by integer domains. We could nonetheless use those parameters as well, but this would lead to the situation, that you can either enable intervals for float __and__ int or __none__, which might not be what you want in some situations
