### PR TITLE
Implement float operators in C / Support Float and Double

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,6 @@
     ppx_deriving_hash
     ppx_deriving_yojson
     (ppx_blob (>= 0.6.0))
-    round
     (ocaml-monadic (>= 0.5))
     (ounit2 :with-test)
     (qcheck-ounit :with-test)

--- a/goblint.opam
+++ b/goblint.opam
@@ -30,7 +30,6 @@ depends: [
   "ppx_deriving_hash"
   "ppx_deriving_yojson"
   "ppx_blob" {>= "0.6.0"}
-  "round"
   "ocaml-monadic" {>= "0.5"}
   "ounit2" {with-test}
   "qcheck-ounit" {with-test}
@@ -74,5 +73,4 @@ pin-depends: [
   # [ "ppx_deriving_yojson.3.6.1" "git+https://github.com/ocaml-ppx/ppx_deriving_yojson.git#e030f13a3450e9cf7d2c43fa04e709ef608486cd" ]
   # TODO: add back after release, only pinned for CI stability
   [ "apron.v0.9.13" "git+https://github.com/antoinemine/apron.git#c852ebcc89e5cf4a5a3318e7c13c73e1756abb11"]
-  [ "round.0.1" "git+https://github.com/brgr/ocaml-round.git#2dfe43050bfdac885607b6697c19c2ed913d5be4"]
 ]

--- a/goblint.opam.locked
+++ b/goblint.opam.locked
@@ -80,7 +80,6 @@ depends: [
   "qcheck-ounit" {= "0.18.1" & with-test}
   "re" {= "1.10.3" & with-doc}
   "result" {= "1.5"}
-  "round" {= "0.1"}
   "seq" {= "base" & with-test}
   "sexplib0" {= "v0.14.0"}
   "sha" {= "1.15.2"}
@@ -126,9 +125,5 @@ pin-depends: [
   [
     "ppx_deriving.5.2.1"
     "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6"
-  ]
-  [
-    "round.0.1"
-    "git+https://github.com/brgr/ocaml-round.git#2dfe43050bfdac885607b6697c19c2ed913d5be4"
   ]
 ]

--- a/goblint.opam.template
+++ b/goblint.opam.template
@@ -8,5 +8,4 @@ pin-depends: [
   # [ "ppx_deriving_yojson.3.6.1" "git+https://github.com/ocaml-ppx/ppx_deriving_yojson.git#e030f13a3450e9cf7d2c43fa04e709ef608486cd" ]
   # TODO: add back after release, only pinned for CI stability
   [ "apron.v0.9.13" "git+https://github.com/antoinemine/apron.git#c852ebcc89e5cf4a5a3318e7c13c73e1756abb11"]
-  [ "round.0.1" "git+https://github.com/brgr/ocaml-round.git#2dfe43050bfdac885607b6697c19c2ed913d5be4"]
 ]

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -727,10 +727,8 @@ struct
       | Const (CInt (num,ikind,str)) ->
         (match str with Some x -> M.tracel "casto" "CInt (%s, %a, %s)\n" (Cilint.string_of_cilint num) d_ikind ikind x | None -> ());
         `Int (ID.cast_to ikind (IntDomain.of_const (num,ikind,str)))
-      | Const (CReal (_, (FFloat as fkind), Some str))
-      | Const (CReal (_, (FDouble as fkind), Some str)) -> `Float (FD.of_string fkind str) (* prefer parsing from string due to higher precision *)
-      | Const (CReal (num, (FFloat as fkind), None))
-      | Const (CReal (num, (FDouble as fkind), None)) -> `Float (FD.of_const fkind num)
+      | Const (CReal (_, (FFloat | FDouble as fkind), Some str)) -> `Float (FD.of_string fkind str) (* prefer parsing from string due to higher precision *)
+      | Const (CReal (num, (FFloat | FDouble as fkind), None)) -> `Float (FD.of_const fkind num)
       (* this is so far only for DBL_MIN/DBL_MAX as it is represented as LongDouble although it would fit into a double as well *)
       | Const (CReal (_, (FLongDouble), Some str)) when str = "2.2250738585072014e-308L" -> `Float (FD.of_string FDouble str)
       | Const (CReal (_, (FLongDouble), Some str)) when str = "1.7976931348623157e+308L" -> `Float (FD.of_string FDouble str)

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -262,7 +262,7 @@ struct
     | `Float v1, `Float v2 when is_int_returning_binop_FD op -> 
       let result_ik = Cilfacade.get_ikind t in
       `Int (ID.cast_to result_ik (int_returning_binop_FD op v1 v2))
-    | `Float v1, `Float v2 -> `Float (binop_FD (Cilfacade.get_fkind t) op v1 v2) (* TODO: add get_fkind once merged *)
+    | `Float v1, `Float v2 -> `Float (binop_FD (Cilfacade.get_fkind t) op v1 v2)
     (* For address +/- value, we try to do some elementary ptr arithmetic *)
     | `Address p, `Int n
     | `Int n, `Address p when op=Eq || op=Ne ->
@@ -731,6 +731,9 @@ struct
       | Const (CReal (_, (FDouble as fkind), Some str)) -> `Float (FD.of_string fkind str) (* prefer parsing from string due to higher precision *)
       | Const (CReal (num, (FFloat as fkind), None))
       | Const (CReal (num, (FDouble as fkind), None)) -> `Float (FD.of_const fkind num)
+      (* this is so far only for DBL_MIN/DBL_MAX as it is represented as LongDouble although it would fit into a double as well *)
+      | Const (CReal (_, (FLongDouble), Some str)) when str = "2.2250738585072014e-308L" -> `Float (FD.of_string FDouble str)
+      | Const (CReal (_, (FLongDouble), Some str)) when str = "1.7976931348623157e+308L" -> `Float (FD.of_string FDouble str)
       (* String literals *)
       | Const (CStr (x,_)) -> `Address (AD.from_string x) (* normal 8-bit strings, type: char* *)
       | Const (CWStr (xs,_) as c) -> (* wide character strings, type: wchar_t* *)

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -1,6 +1,7 @@
 open Pretty
 open PrecisionUtil
-open Round
+open FloatOps
+open Cil
 
 module type FloatArith = sig
   type t
@@ -35,66 +36,49 @@ module type FloatDomainBase = sig
   include Lattice.S
   include FloatArith with type t := t
 
+  val to_int : Cil.ikind -> t -> IntDomain.IntDomTuple.t
+
   val of_const : float -> t
-  val of_interval : float*float -> t 
+  val of_interval : float * float -> t
+  val of_string : string -> t
+  val of_int: IntDomain.IntDomTuple.t -> t
+
   val ending : float -> t
   val starting : float -> t
 
-  val to_float : t -> float option
-  val maximal : t -> float option
-  val minimal : t -> float option
+  val minimal: t -> float option
+  val maximal: t -> float option
 
-  val of_int : IntDomain.IntDomTuple.t -> t
-  val cast_to : Cil.ikind -> t -> IntDomain.IntDomTuple.t
+  val is_exact : t -> bool
 end
-module FloatInterval = struct
+
+module FloatIntervalImpl(Float_t : CFloatType) = struct
   include Printable.Std (* for default invariant, tag and relift *)
-  type t = (float * float) option [@@deriving eq, ord, to_yojson]
+  type t = (Float_t.t * Float_t.t) option [@@deriving eq, ord, to_yojson]
 
-  let show = function
-    | None -> "Float[Top]"
-    | Some (low, high) -> Printf.sprintf "Float [%.30f,%.30f]" low high
+  let hash = Hashtbl.hash
 
-  let big_int_of_float f =
-    let x, n = Float.frexp f in
-    let shift = min 52 n in
-    let x' = x *. Float.pow 2. (Float.of_int shift) in
-    Big_int_Z.mult_big_int
-      (Big_int_Z.big_int_of_int64 (Int64.of_float x'))
-      (Big_int_Z.power_int_positive_int 2 (n - shift))
-
-  let cast_to ik = function
+  let to_int ik = function
     | None -> IntDomain.IntDomTuple.top_of ik
     | Some (l, h) -> 
       (* as converting from float to integer is (exactly) defined as leaving out the fractional part,
          (value is truncated towrad zero) we do not require specific rounding here *)
-      IntDomain.IntDomTuple.of_interval ik (big_int_of_float l, big_int_of_float h)
+      IntDomain.IntDomTuple.of_interval ik (Float_t.to_big_int l, Float_t.to_big_int h)
 
-  let of_int x = match IntDomain.IntDomTuple.minimal x, IntDomain.IntDomTuple.maximal x with
-    | Some l, Some h when l >= big_int_of_float (-. Float.max_float) && h <= big_int_of_float Float.max_float ->
-      let l' = Big_int_Z.float_of_big_int l in
-      let l'' = if big_int_of_float (l') <= l then l' else Float.pred l' in
-      let h' = Big_int_Z.float_of_big_int h in
-      let h'' = if big_int_of_float (h') >= h then h' else Float.succ h' in
-      if l'' = Float.neg_infinity || h'' = Float.infinity then
+  let of_int x = 
+    match IntDomain.IntDomTuple.minimal x, IntDomain.IntDomTuple.maximal x with
+    | Some l, Some h when l >= Float_t.to_big_int Float_t.lower_bound && h <= Float_t.to_big_int Float_t.upper_bound ->
+      let l' = Float_t.of_float Down (Big_int_Z.float_of_big_int l) in
+      let h' = Float_t.of_float Up (Big_int_Z.float_of_big_int h) in
+      if not (Float_t.is_finite l' && Float_t.is_finite h') then
         None
       else
-        Some (l'', h'')
+        Some (l', h')
     | _, _ -> None
 
-  let maximal = function
-    | Some (_, h) -> Some h
-    | _ -> None
-
-  let minimal = function
-    | Some (l, _) -> Some l
-    | _ -> None
-
-  let to_float = function
-    | Some (l, h) when l = h -> Some l
-    | _ -> None
-
-  let hash = Hashtbl.hash
+  let show = function
+    | None -> "Float[Top]"
+    | Some (low, high) -> Printf.sprintf "Float [%s,%s]" (Float_t.to_string low) (Float_t.to_string high)
 
   let pretty () x = text (show x)
 
@@ -115,12 +99,12 @@ module FloatInterval = struct
 
   let is_top = Option.is_none
 
-  let neg = Option.map (fun (low, high) -> (-.high, -.low))
+  let neg = Option.map (fun (low, high) -> (Float_t.neg high, Float_t.neg low))
 
   let norm v = 
     let normed = match v with
       | Some (low, high) -> 
-        if Float.is_finite low && Float.is_finite high then 
+        if Float_t.is_finite low && Float_t.is_finite high then 
           if low > high then failwith "invalid Interval"
           else v
         else None
@@ -134,18 +118,25 @@ module FloatInterval = struct
   let norm_arb v = 
     match v with
     | Some (f1, f2) ->
-      if Float.is_finite f1 && Float.is_finite f2 
+      if Float_t.is_finite f1 && Float_t.is_finite f2 
       then Some(min f1 f2, max f1 f2) 
       else None
     | _ -> None
 
-  (**for QCheck: should describe how to generate random values and shrink possilbe counter examples *)
-  let arbitrary () = QCheck.map norm_arb (QCheck.option (QCheck.pair QCheck.float QCheck.float)) 
+  (**for QCheck: should describe how to generate random values and shrink possible counter examples *)
+  let arbitrary () = QCheck.map norm_arb (QCheck.option (QCheck.pair (Float_t.arbitrary ()) (Float_t.arbitrary ()))) 
 
-  let of_interval (l, h) = norm @@ Some (min l h, max l h)
+  let of_interval (l, h) = norm @@ Some (Float_t.of_float Down (min l h), Float_t.of_float Up (max l h))
+  let of_const f = of_interval (f, f)
+  let of_string s = norm @@ Some (Float_t.atof Down s, Float_t.atof Up s)
+
   let ending end_value = of_interval (-. max_float, end_value)
   let starting start_value = of_interval (start_value, max_float)
-  let of_const f = of_interval (f, f)
+
+  let minimal = function Some (l, v) -> Float_t.to_float l | _ -> None
+  let maximal = function Some (l, v) -> Float_t.to_float v | _ -> None
+
+  let is_exact = function Some (l, v) -> l = v | _ -> false
 
   let leq v1 v2 = 
     match v1, v2 with
@@ -174,8 +165,8 @@ module FloatInterval = struct
     | Some (l1, h1), Some (l2, h2) ->
       (**If we widen and we know that neither interval contains +-inf or nan, it is ok to widen only to +-max_float, 
          because a widening with +-inf/nan will always result in the case above -> Top *)
-      let low = if l1 <= l2 then l1 else (-.Float.max_float) in 
-      let high = if h1 >= h2 then h1 else Float.max_float in
+      let low = if l1 <= l2 then l1 else Float_t.lower_bound in 
+      let high = if h1 >= h2 then h1 else Float_t.upper_bound in
       norm @@ Some (low, high)
 
   let narrow v1 v2 = (**TODO: support 'threshold_narrowing' and 'narrow_by_meet' option *)
@@ -189,7 +180,7 @@ module FloatInterval = struct
     | Some v1, Some v2 -> eval_operation v1 v2
     | _ -> None
 
-  let eval_int_binop eval_operation op1 op2 =
+  let eval_int_binop eval_operation (op1: t) op2 =
     let a, b =
       match (op1, op2) with 
       | Some v1, Some v2 -> eval_operation v1 v2 
@@ -199,35 +190,35 @@ module FloatInterval = struct
       (Big_int_Z.big_int_of_int a, Big_int_Z.big_int_of_int b)
 
   let eval_add (l1, h1) (l2, h2) = 
-    Some (add Down l1 l2, add Up h1 h2)
+    Some (Float_t.add Down l1 l2, Float_t.add Up h1 h2)
 
   let eval_sub (l1, h1) (l2, h2) = 
-    Some (sub Down l1 h2, sub Up h1 l2)
+    Some (Float_t.sub Down l1 h2, Float_t.sub Up h1 l2)
 
   let eval_mul (l1, h1) (l2, h2) =
-    let mul1u = mul Up l1 l2 in
-    let mul2u = mul Up l1 h2 in
-    let mul3u = mul Up h1 l2 in
-    let mul4u = mul Up h1 h2 in
-    let mul1d = mul Down l1 l2 in
-    let mul2d = mul Down l1 h2 in
-    let mul3d = mul Down h1 l2 in
-    let mul4d = mul Down h1 h2 in
+    let mul1u = Float_t.mul Up l1 l2 in
+    let mul2u = Float_t.mul Up l1 h2 in
+    let mul3u = Float_t.mul Up h1 l2 in
+    let mul4u = Float_t.mul Up h1 h2 in
+    let mul1d = Float_t.mul Down l1 l2 in
+    let mul2d = Float_t.mul Down l1 h2 in
+    let mul3d = Float_t.mul Down h1 l2 in
+    let mul4d = Float_t.mul Down h1 h2 in
     let high = max (max (max mul1u mul2u) mul3u) mul4u in
     let low = min (min (min mul1d mul2d) mul3d) mul4d in
     Some (low, high)
 
   let eval_div (l1, h1) (l2, h2) =
-    if l2 <= 0. && h2 >= 0. then None
+    if l2 <= Float_t.zero && h2 >= Float_t.zero then None
     else
-      let div1u = div Up l1 l2 in
-      let div2u = div Up l1 h2 in
-      let div3u = div Up h1 l2 in
-      let div4u = div Up h1 h2 in
-      let div1d = div Down l1 l2 in
-      let div2d = div Down l1 h2 in
-      let div3d = div Down h1 l2 in
-      let div4d = div Down h1 h2 in
+      let div1u = Float_t.div Up l1 l2 in
+      let div2u = Float_t.div Up l1 h2 in
+      let div3u = Float_t.div Up h1 l2 in
+      let div4u = Float_t.div Up h1 h2 in
+      let div1d = Float_t.div Down l1 l2 in
+      let div2d = Float_t.div Down l1 h2 in
+      let div3d = Float_t.div Down h1 l2 in
+      let div4d = Float_t.div Down h1 h2 in
       let high = max (max (max div1u div2u) div3u) div4u in
       let low = min (min (min div1d div2d) div3d) div4d in
       Some (low, high)
@@ -285,16 +276,141 @@ module FloatInterval = struct
 
 end
 
+module F64Interval = FloatIntervalImpl(CDouble)
+module F32Interval = FloatIntervalImpl(CFloat)
+
+module type FloatDomain = sig
+  include Lattice.S
+  include FloatArith with type t := t
+
+  val to_int : Cil.ikind -> t -> IntDomain.IntDomTuple.t
+  val cast_to : Cil.fkind -> t -> t
+
+  val of_const : Cil.fkind -> float -> t
+  val of_interval : Cil.fkind -> float*float -> t
+  val of_string : Cil.fkind -> string -> t
+  val of_int: Cil.fkind -> IntDomain.IntDomTuple.t -> t
+
+  val top_of: Cil.fkind -> t
+  val bot_of: Cil.fkind -> t
+
+  val ending : Cil.fkind -> float -> t
+  val starting : Cil.fkind -> float -> t
+
+  val minimal: t -> float option
+  val maximal: t -> float option
+
+  val is_exact : t -> bool
+  val precision : t -> Cil.fkind
+end
+
+module FloatIntervalImplLifted = struct
+  include Printable.Std (* for default invariant, tag and relift *)
+  type t = F32 of F32Interval.t | F64 of F64Interval.t [@@deriving to_yojson, eq, ord, hash]
+
+  module F1 = F32Interval
+  module F2 = F64Interval
+
+  let lift2 (op32, op64) x y = match x, y with
+    | F32 a, F32 b -> F32 (op32 a b)
+    | F64 a, F64 b -> F64 (op64 a b)
+    | F32 a, F64 b -> failwith ("fkinds float and double are incompatible. Values: " ^ Prelude.Ana.sprint F32Interval.pretty a ^ " and " ^ Prelude.Ana.sprint F64Interval.pretty b)
+    | F64 a, F32 b -> failwith ("fkinds double and float are incompatible. Values: " ^ Prelude.Ana.sprint F64Interval.pretty a ^ " and " ^ Prelude.Ana.sprint F32Interval.pretty b)
+
+  let lift2_cmp (op32, op64) x y = match x, y with
+    | F32 a, F32 b -> op32 a b
+    | F64 a, F64 b -> op64 a b
+    | F32 a, F64 b -> failwith ("fkinds float and double are incompatible. Values: " ^ Prelude.Ana.sprint F32Interval.pretty a ^ " and " ^ Prelude.Ana.sprint F64Interval.pretty b)
+    | F64 a, F32 b -> failwith ("fkinds double and float are incompatible. Values: " ^ Prelude.Ana.sprint F64Interval.pretty a ^ " and " ^ Prelude.Ana.sprint F32Interval.pretty b)
+
+  let lift (op32, op64) x = match x with
+    | F32 a -> F32 (op32 a)
+    | F64 a -> F64 (op64 a)
+
+  let dispatch (op32, op64) x = match x with
+    | F32 a -> op32 a
+    | F64 a -> op64 a
+
+  let dispatch_fkind fkind (op32, op64) = match fkind with
+    | FFloat -> F32 (op32 ())
+    | FDouble -> F64 (op64 ()) 
+    | _ -> failwith "unsupported fkind"
+
+  let neg = function 
+    | F32 x -> F32 (F1.neg x)
+    | F64 x -> F64 (F2.neg x)
+  let add = lift2 (F1.add, F2.add)
+  let sub = lift2 (F1.sub, F2.sub)
+  let mul = lift2 (F1.mul, F2.mul)
+  let div = lift2 (F1.div, F2.div)
+  let lt = lift2_cmp (F1.lt, F2.lt)
+  let gt = lift2_cmp (F1.gt, F2.gt)
+  let le = lift2_cmp (F1.le, F2.le)
+  let ge = lift2_cmp (F1.ge, F2.ge)
+  let eq = lift2_cmp (F1.eq, F2.eq)
+  let ne = lift2_cmp (F1.ne, F2.ne)
+
+  let bot_of fkind = dispatch_fkind fkind (F1.bot, F2.bot)
+  let bot () = failwith "bot () is not implemented for IntDomLifter."
+  let is_bot = dispatch (F1.is_bot, F2.is_bot)
+  let top_of fkind = dispatch_fkind fkind (F1.top, F2.top)
+  let top () = failwith "top () is not implemented for IntDomLifter."
+  let is_top = dispatch (F1.is_bot, F2.is_bot)
+
+  let precision = dispatch ((fun _ -> FFloat), (fun _ -> FDouble))
+
+  let leq = lift2_cmp (F1.leq, F2.leq)
+  let join = lift2 (F1.join, F2.join)
+  let meet = lift2 (F1.meet, F2.meet)
+  let widen = lift2 (F1.widen, F2.widen)
+  let narrow = lift2 (F1.narrow, F2.narrow)
+  let is_exact = dispatch (F1.is_exact, F2.is_exact)
+
+  let show = dispatch (F1.show, F2.show)  (* TODO add fkind to output *)
+  let pretty = (fun () -> dispatch (F1.pretty (), F2.pretty ())) (* TODO add fkind to output *)
+
+  let pretty_diff () (x, y) = lift2_cmp ((fun a b -> F1.pretty_diff () (a, b)), (fun a b -> F2.pretty_diff () (a, b))) x y(* TODO add fkind to output *)
+  let printXml o = dispatch (F1.printXml o, F2.printXml o) (* TODO add fkind to output *)
+
+  (* This is for debugging *)
+  let name () = "FloatIntervalImplLifted(F32|F64)"
+  let to_yojson = dispatch (F1.to_yojson, F2.to_yojson)
+  let tag = dispatch (F1.tag, F2.tag)
+  let arbitrary fk = failwith @@ "Arbitrary not implement for " ^ (name ()) ^ "."
+
+  let of_const fkind x = dispatch_fkind fkind ((fun () -> F1.of_const x), (fun () -> F2.of_const x))
+  let of_string fkind str = dispatch_fkind fkind ((fun () -> F1.of_string str), (fun () -> F2.of_string str))
+  let of_int fkind i = dispatch_fkind fkind ((fun () -> F1.of_int i), (fun () -> F2.of_int i))
+  let of_interval fkind i = dispatch_fkind fkind ((fun () -> F1.of_interval i), (fun () -> F2.of_interval i))
+  let starting fkind s = dispatch_fkind fkind ((fun () -> F1.starting s), (fun () -> F2.starting s))
+  let ending fkind e = dispatch_fkind fkind ((fun () -> F1.ending e), (fun () -> F2.ending e))
+  let minimal = dispatch (F1.minimal, F2.minimal)
+  let maximal = dispatch (F1.maximal, F2.maximal)
+  let to_int ikind = dispatch (F1.to_int ikind, F2.to_int ikind)
+  let cast_to fkind x =
+    let create_interval fkind l h = 
+      match l, h with 
+      | Some l, Some h -> of_interval fkind (l,h)
+      | Some l, None -> starting fkind l
+      | None, Some h -> ending fkind h
+      | _ -> top_of fkind
+    in 
+    match x, fkind with
+    | F32 a, FDouble -> create_interval FDouble (F1.minimal a) (F1.maximal a)
+    | F64 a, FFloat -> create_interval FFloat (F2.minimal a) (F2.maximal a)
+    | _ -> x
+end
+
 module FloatDomTupleImpl = struct
   include Printable.Std (* for default invariant, tag, ... *)
-  module F1 = FloatInterval
+  module F1 = FloatIntervalImplLifted
   open Batteries
 
   type t = F1.t option [@@deriving to_yojson, eq, ord]
 
   let name () = "floatdomtuple"
 
-  type 'a m = (module FloatDomainBase with type t = 'a)
+  type 'a m = (module FloatDomain with type t = 'a)
   (* only first-order polymorphism on functions 
      -> use records to get around monomorphism restriction on arguments (Same trick as used in intDomain) *)
   type 'b poly_in = { fi : 'a. 'a m -> 'b -> 'a }
@@ -331,97 +447,113 @@ module FloatDomTupleImpl = struct
 
   let show x =
     Option.map_default identity ""
-      (mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) x -> F.name () ^ ":" ^ F.show x); } x)
+      (mapp { fp= (fun (type a) (module F : FloatDomain with type t = a) x -> F.name () ^ ":" ^ F.show x); } x)
 
   let to_yojson =
     [%to_yojson: Yojson.Safe.t option]
-    % mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.to_yojson); }
+    % mapp { fp= (fun (type a) (module F : FloatDomain with type t = a) -> F.to_yojson); }
   let hash x =
     Option.map_default identity 0
-      (mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.hash); } x)
+      (mapp { fp= (fun (type a) (module F : FloatDomain with type t = a) -> F.hash); } x)
 
-  let of_const =
-    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.of_const); }
-  let of_interval =
-    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.of_interval); }
-  let ending =
-    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.ending); }
-  let starting =
-    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.starting); }
+  let of_const fkind =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.of_const fkind); }
 
-  let to_float = function
-    | Some (x) -> F1.to_float x
-    | _ -> None
+  let of_interval fkind =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.of_interval fkind); }
+  let ending fkind =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.ending fkind); }
+  let starting fkind =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.starting fkind); }
 
-  let maximal = function
-    | Some (x) -> F1.maximal x
-    | _ -> None
-  let minimal = function
-    | Some (x) -> F1.minimal x
-    | _ -> None
+  let of_string fkind =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.of_string fkind); }
 
   let top =
-    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.top); }
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.top); }
   let bot =
-    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.bot); }
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.bot); }
+  let top_of =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.top_of); }
+  let bot_of =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.bot_of); }
+
   let is_bot =
     exists
-    % mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.is_bot); }
+    % mapp { fp= (fun (type a) (module F : FloatDomain with type t = a) -> F.is_bot); }
+  let is_exact =
+    exists
+    % mapp { fp= (fun (type a) (module F : FloatDomain with type t = a) -> F.is_exact); }
   let is_top =
     for_all
-    % mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.is_top); }
+    % mapp { fp= (fun (type a) (module F : FloatDomain with type t = a) -> F.is_top); }
 
-  let of_int =
-    create { fi= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.of_int); }
+  let precision = function
+    | Some f -> F1.precision f
+    | None -> failwith "invalid"
 
-  let cast_to ik x =
+  let minimal = function
+    | Some f -> F1.minimal f
+    | None -> None
+
+  let maximal = function
+    | Some f -> F1.maximal f
+    | None -> None
+
+  let of_int fkind =
+    create { fi= (fun (type a) (module F : FloatDomain with type t = a) -> F.of_int fkind); }
+
+  let to_int ik x =
     match x with
-    | Some f -> F1.cast_to ik f
+    | Some f -> F1.to_int ik f
     | None -> IntDomain.IntDomTuple.top_of ik
+
+  let cast_to fkind =
+    map { f1= (fun (type a) (module F : FloatDomain with type t = a) -> (fun x -> F.cast_to fkind x)); }
 
   let leq =
     for_all
-    %% map2p { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.leq); }
+    %% map2p { f2p= (fun (type a) (module F : FloatDomain with type t = a) -> F.leq); }
 
   let pretty () x =
     Option.map_default identity nil
-      (mapp { fp= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.pretty ()); } x)
+      (mapp { fp= (fun (type a) (module F : FloatDomain with type t = a) -> F.pretty ()); } x)
 
   (* f1: one and only unary op *)
   let neg =
-    map { f1= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.neg); }
+    map { f1= (fun (type a) (module F : FloatDomain with type t = a) -> F.neg); }
 
   (* f2: binary ops *)
   let join =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.join); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.join); }
   let meet =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.meet); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.meet); }
   let widen =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.widen); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.widen); }
   let narrow =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.narrow); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.narrow); }
   let add =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.add); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.add); }
   let sub =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.sub); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.sub); }
   let mul =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.mul); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.mul); }
   let div =
-    map2 { f2= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.div); }
+    map2 { f2= (fun (type a) (module F : FloatDomain with type t = a) -> F.div); }
 
   (* f2: binary ops which return an integer *)
   let lt =
-    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.lt); }
+    map2int { f2p= (fun (type a) (module F : FloatDomain with type t = a) -> F.lt); }
   let gt =
-    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.gt); }
+    map2int { f2p= (fun (type a) (module F : FloatDomain with type t = a) -> F.gt); }
   let le =
-    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.le); }
+    map2int { f2p= (fun (type a) (module F : FloatDomain with type t = a) -> F.le); }
   let ge =
-    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.ge); }
+    map2int { f2p= (fun (type a) (module F : FloatDomain with type t = a) -> F.ge); }
   let eq =
-    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.eq); }
+    map2int { f2p= (fun (type a) (module F : FloatDomain with type t = a) -> F.eq); }
   let ne =
-    map2int { f2p= (fun (type a) (module F : FloatDomainBase with type t = a) -> F.ne); }
+    map2int { f2p= (fun (type a) (module F : FloatDomain with type t = a) -> F.ne); }
 
   let pretty_diff () (x, y) = dprintf "%a instead of %a" pretty x pretty y
 

--- a/src/cdomains/floatDomain.mli
+++ b/src/cdomains/floatDomain.mli
@@ -30,52 +30,59 @@ module type FloatArith = sig
   (** Not equal to: [x != y] *)
 end
 
-module FloatInterval : sig (**Currently just for FloatDomainTest *)
-  type t = (float * float) option
-  include FloatArith with type t := t
-  include Lattice.S  with type t := t
-
-  val top : unit -> t
-
-  val is_bot : t -> bool
-
-  val is_top : t -> bool
-
-  val of_const : float -> t
-  val of_interval : float*float -> t
-  val of_int : IntDomain.IntDomTuple.t -> t
-  val cast_to : Cil.ikind -> t -> IntDomain.IntDomTuple.t
-
-  val ending : float -> t
-  val starting : float -> t
-
-  val show : t -> string
-
-  val equal : t -> t -> bool
-
-  val leq : t -> t -> bool
-
-  val arbitrary : unit -> t QCheck.arbitrary
-end
-
 module type FloatDomainBase = sig
   include Lattice.S
   include FloatArith with type t := t
 
+  val to_int : Cil.ikind -> t -> IntDomain.IntDomTuple.t
+
   val of_const : float -> t
-  val of_interval : float*float -> t
+  val of_interval : float * float -> t
+  val of_string : string -> t
+  val of_int: IntDomain.IntDomTuple.t -> t
 
   val ending : float -> t
   val starting : float -> t
 
-  val to_float : t -> float option
-  val maximal : t -> float option
-  val minimal : t -> float option
+  val minimal: t -> float option
+  val maximal: t -> float option
 
-  val of_int : IntDomain.IntDomTuple.t -> t
-  val cast_to : Cil.ikind -> t -> IntDomain.IntDomTuple.t
+  val is_exact : t -> bool
+end
+
+(* Only required for testing *)
+module F64Interval : sig
+  include FloatDomainBase
+end
+module F32Interval : sig
+  include FloatDomainBase
+end
+
+module type FloatDomain = sig
+  include Lattice.S
+  include FloatArith with type t := t
+
+  val to_int : Cil.ikind -> t -> IntDomain.IntDomTuple.t
+  val cast_to : Cil.fkind -> t -> t
+
+  val of_const : Cil.fkind -> float -> t
+  val of_interval : Cil.fkind -> float*float -> t
+  val of_string : Cil.fkind -> string -> t
+  val of_int: Cil.fkind -> IntDomain.IntDomTuple.t -> t
+
+  val top_of: Cil.fkind -> t
+  val bot_of: Cil.fkind -> t
+
+  val ending : Cil.fkind -> float -> t
+  val starting : Cil.fkind -> float -> t
+
+  val minimal: t -> float option
+  val maximal: t -> float option
+
+  val is_exact : t -> bool
+  val precision : t -> Cil.fkind
 end
 
 module FloatDomTupleImpl : sig
-  include FloatDomainBase
+  include FloatDomain
 end

--- a/src/cdomains/floatDomain.mli
+++ b/src/cdomains/floatDomain.mli
@@ -51,12 +51,8 @@ module type FloatDomainBase = sig
 end
 
 (* Only required for testing *)
-module F64Interval : sig
-  include FloatDomainBase
-end
-module F32Interval : sig
-  include FloatDomainBase
-end
+module F64Interval : FloatDomainBase
+module F32Interval : FloatDomainBase
 
 module type FloatDomain = sig
   include Lattice.S

--- a/src/cdomains/floatOps/floatOps.ml
+++ b/src/cdomains/floatOps/floatOps.ml
@@ -1,0 +1,97 @@
+type round_mode =
+  | Nearest
+  | ToZero
+  | Up
+  | Down
+
+module type CFloatType = sig
+  type t
+
+  val zero: t
+  val upper_bound: t
+  val lower_bound: t
+
+  val of_float: round_mode -> float -> t
+  val to_float: t -> float option
+  val to_big_int: t -> Big_int_Z.big_int
+
+  val is_finite: t -> bool
+  val pred: t -> t
+  val succ: t -> t
+
+  val arbitrary: unit -> t QCheck.arbitrary
+  val equal: t -> t -> bool
+  val compare: t -> t -> int
+  val to_yojson: t -> Yojson.Safe.t
+  val to_string: t -> string
+
+  val neg: t -> t
+  val add: round_mode -> t -> t -> t
+  val sub: round_mode -> t -> t -> t
+  val mul: round_mode -> t -> t -> t
+  val div: round_mode -> t -> t -> t
+  val atof: round_mode -> string -> t
+end
+
+let big_int_of_float f =
+  let x, n = Float.frexp f in
+  let shift = min 52 n in
+  let x' = x *. Float.pow 2. (Float.of_int shift) in
+  Big_int_Z.mult_big_int
+    (Big_int_Z.big_int_of_int64 (Int64.of_float x'))
+    (Big_int_Z.power_int_positive_int 2 (n - shift))
+
+module CDouble = struct
+  type t = float [@@deriving eq, ord, to_yojson]
+
+  let zero = Float.zero
+  let upper_bound = Float.max_float
+  let lower_bound = -. Float.max_float
+
+  let of_float _ x = x
+  let to_float x = Some x
+  let to_big_int = big_int_of_float
+
+  let is_finite = Float.is_finite
+  let pred = Float.pred
+  let succ = Float.succ
+
+  let arbitrary () = QCheck.float
+  let to_string = Float.to_string
+
+  let neg = Float.neg
+  external add: round_mode -> t -> t -> t = "add_double"
+  external sub: round_mode -> t -> t -> t = "sub_double"
+  external mul: round_mode -> t -> t -> t = "mul_double"
+  external div: round_mode -> t -> t -> t = "div_double"
+
+  external atof: round_mode -> string -> t = "atof_double"
+end
+
+module CFloat = struct
+  type t = float [@@deriving eq, ord, to_yojson]
+
+  let zero = Float.zero
+  let upper_bound = 3.402823e+38
+  let lower_bound = -. 3.402823e+38
+
+  let to_float x = Some x
+  let to_big_int = big_int_of_float
+
+  let is_finite = Float.is_finite
+  let pred = Float.pred
+  let succ = Float.succ
+
+  let arbitrary () = QCheck.float
+  let to_string = Float.to_string
+
+  let neg = Float.neg
+  external add: round_mode -> t -> t -> t = "add_float"
+  external sub: round_mode -> t -> t -> t = "sub_float"
+  external mul: round_mode -> t -> t -> t = "mul_float"
+  external div: round_mode -> t -> t -> t = "div_float"
+
+  external atof: round_mode -> string -> t = "atof_float"
+
+  let of_float mode x = add mode zero x
+end

--- a/src/cdomains/floatOps/floatOps.mli
+++ b/src/cdomains/floatOps/floatOps.mli
@@ -7,9 +7,11 @@ type round_mode =
 module type CFloatType = sig
   type t
 
+  val name: string
   val zero: t
   val upper_bound: t
   val lower_bound: t
+  val smallest : t
 
   val of_float: round_mode -> float -> t
   val to_float: t -> float option
@@ -19,7 +21,6 @@ module type CFloatType = sig
   val pred: t -> t
   val succ: t -> t
 
-  val arbitrary: unit -> t QCheck.arbitrary
   val equal: t -> t -> bool
   val compare: t -> t -> int
   val to_yojson: t -> Yojson.Safe.t

--- a/src/cdomains/floatOps/floatOps.mli
+++ b/src/cdomains/floatOps/floatOps.mli
@@ -1,0 +1,39 @@
+type round_mode =
+  | Nearest
+  | ToZero
+  | Up
+  | Down
+
+module type CFloatType = sig
+  type t
+
+  val zero: t
+  val upper_bound: t
+  val lower_bound: t
+
+  val of_float: round_mode -> float -> t
+  val to_float: t -> float option
+  val to_big_int: t -> Big_int_Z.big_int
+
+  val is_finite: t -> bool
+  val pred: t -> t
+  val succ: t -> t
+
+  val arbitrary: unit -> t QCheck.arbitrary
+  val equal: t -> t -> bool
+  val compare: t -> t -> int
+  val to_yojson: t -> Yojson.Safe.t
+  val to_string: t -> string
+
+
+  val neg: t -> t
+  val add: round_mode -> t -> t -> t
+  val sub: round_mode -> t -> t -> t
+  val mul: round_mode -> t -> t -> t
+  val div: round_mode -> t -> t -> t
+  val atof: round_mode -> string -> t
+end
+
+module CDouble : CFloatType
+module CFloat : CFloatType
+

--- a/src/cdomains/floatOps/stubs.c
+++ b/src/cdomains/floatOps/stubs.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <math.h>
+#include <fenv.h>
+#include <assert.h>
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+
+enum round_mode
+{
+    Nearest,
+    ToZero,
+    Up,
+    Down
+};
+
+static void change_round_mode(int mode)
+{
+    switch (mode)
+    {
+    case Nearest:
+        fesetround(FE_TONEAREST);
+        break;
+    case ToZero:
+        fesetround(FE_TOWARDZERO);
+        break;
+    case Up:
+        fesetround(FE_UPWARD);
+        break;
+    case Down:
+        fesetround(FE_DOWNWARD);
+        break;
+    default:
+        assert(0);
+        break;
+    }
+}
+
+#define BINARY_OP(name, type, op)                                \
+    CAMLprim value name##_##type(value mode, value x, value y)   \
+    {                                                            \
+        volatile type r, x1 = Double_val(x), y1 = Double_val(y); \
+        change_round_mode(Int_val(mode));                        \
+        r = x1 op y1;                                            \
+        change_round_mode(Nearest);                              \
+        return caml_copy_double(r);                              \
+    }
+
+BINARY_OP(add, double, +);
+BINARY_OP(add, float, +);
+BINARY_OP(sub, double, -);
+BINARY_OP(sub, float, -);
+BINARY_OP(mul, double, *);
+BINARY_OP(mul, float, *);
+BINARY_OP(div, double, /);
+BINARY_OP(div, float, /);
+
+CAMLprim value atof_double(value mode, value str)
+{
+    const char *s = String_val(str);
+    volatile double r;
+    change_round_mode(Int_val(mode));
+    r = atof(s);
+    change_round_mode(Nearest);
+    return caml_copy_double(r);
+}
+
+CAMLprim value atof_float(value mode, value str)
+{
+    const char *s = String_val(str);
+    volatile float r;
+    change_round_mode(Int_val(mode));
+    r = (float)atof(s);
+    change_round_mode(Nearest);
+    return caml_copy_double(r);
+}

--- a/src/cdomains/floatOps/stubs.c
+++ b/src/cdomains/floatOps/stubs.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <math.h>
+#include <float.h>
 #include <fenv.h>
 #include <assert.h>
 #include <caml/mlvalues.h>
@@ -38,8 +39,8 @@ static void change_round_mode(int mode)
 #define BINARY_OP(name, type, op)                                \
     CAMLprim value name##_##type(value mode, value x, value y)   \
     {                                                            \
-        volatile type r, x1 = Double_val(x), y1 = Double_val(y); \
         change_round_mode(Int_val(mode));                        \
+        volatile type r, x1 = Double_val(x), y1 = Double_val(y); \
         r = x1 op y1;                                            \
         change_round_mode(Nearest);                              \
         return caml_copy_double(r);                              \
@@ -72,4 +73,15 @@ CAMLprim value atof_float(value mode, value str)
     r = (float)atof(s);
     change_round_mode(Nearest);
     return caml_copy_double(r);
+}
+
+
+CAMLprim value max_float(value unit)
+{
+    return caml_copy_double(FLT_MAX);
+}
+
+CAMLprim value smallest_float(value unit)
+{
+    return caml_copy_double(FLT_MIN);
 }

--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -148,9 +148,7 @@ struct
     match t with
     | t when is_mutex_type t -> `Top
     | TInt (ik,_) -> `Int (ID.top_of ik)
-    | TFloat (FFloat as fkind, _)
-    | TFloat (FDouble as fkind, _) -> `Float (FD.top_of fkind)
-    | TFloat (fk, _) -> `Top (* TODO(Practical2022): extend to other floating point types *)
+    | TFloat (FFloat | FDouble as fkind, _) -> `Float (FD.top_of fkind)
     | TPtr _ -> `Address AD.top_ptr
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> init_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
@@ -166,9 +164,7 @@ struct
   let rec top_value (t: typ): t =
     match t with
     | TInt (ik,_) -> `Int (ID.(cast_to ik (top_of ik)))
-    | TFloat (FFloat as fkind, _)
-    | TFloat (FDouble as fkind, _) -> `Float (FD.top_of fkind)
-    | TFloat (fk, _) -> `Top (* TODO(Practical2022): extend to other floating point types *)
+    | TFloat (FFloat | FDouble as fkind, _) -> `Float (FD.top_of fkind)
     | TPtr _ -> `Address AD.top_ptr
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> top_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
@@ -197,8 +193,7 @@ struct
     let rec zero_init_value (t:typ): t =
       match t with
       | TInt (ikind, _) -> `Int (ID.of_int ikind BI.zero)
-      | TFloat (FFloat as fkind, _)
-      | TFloat (FDouble as fkind, _) -> `Float (FD.of_const fkind 0.0)
+      | TFloat (FFloat | FDouble as fkind, _) -> `Float (FD.of_const fkind 0.0)
       | TPtr _ -> `Address AD.null_ptr
       | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> zero_init_value fd.ftype) ci)
       | TComp ({cstruct=false; _} as ci,_) ->
@@ -376,12 +371,6 @@ struct
       let log_top (_,l,_,_) = Messages.tracel "cast" "log_top at %d: %a to %a is top!\n" l pretty v d_type t in
       let t = unrollType t in
       let v' = match t with
-        | TFloat (FFloat as fkind,_)
-        | TFloat (FDouble as fkind,_) ->
-          (match v with
-           |`Int ix ->  `Float (FD.of_int fkind ix)
-           |`Float fx ->  `Float (FD.cast_to fkind fx)
-           | _ -> log_top __POS__; `Top)
         | TInt (ik,_) ->
           `Int (ID.cast_to ?torg ik (match v with
               | `Int x -> x
@@ -394,6 +383,11 @@ struct
                 (match Structs.get x first with `Int x -> x | _ -> raise CastError)*)
               | _ -> log_top __POS__; ID.top_of ik
             ))
+        | TFloat (FFloat | FDouble as fkind,_) ->
+          (match v with
+           |`Int ix ->  `Float (FD.of_int fkind ix)
+           |`Float fx ->  `Float (FD.cast_to fkind fx)
+           | _ -> log_top __POS__; `Top)
         | TEnum ({ekind=ik; _},_) ->
           `Int (ID.cast_to ?torg ik (match v with
               | `Int x -> (* TODO warn if x is not in the constant values of ei.eitems? (which is totally valid (only ik is relevant for wrapping), but might be unintended) *) x

--- a/src/dune
+++ b/src/dune
@@ -8,7 +8,7 @@
   (public_name goblint.lib)
   (wrapped false)
   (modules :standard \ goblint mainarinc mainspec privPrecCompare apronPrecCompare messagesCompare)
-  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu arg-complete fpath round
+  (libraries goblint.sites goblint-cil.all-features batteries.unthreaded qcheck-core.runner sha json-data-encoding jsonrpc cpu arg-complete fpath
     ; Conditionally compile based on whether apron optional dependency is installed or not.
     ; Alternative dependencies seem like the only way to optionally depend on optional dependencies.
     ; See: https://dune.readthedocs.io/en/stable/concepts.html#alternative-dependencies.
@@ -33,6 +33,7 @@
       (-> violationZ3.no-z3.ml)
     )
   )
+  (foreign_stubs (language c) (names stubs))
   (preprocess
     (pps ppx_deriving.std ppx_deriving_hash ppx_deriving_yojson
       ppx_distr_guards ocaml-monadic ppx_blob))

--- a/tests/regression/56-floats/01-base.c
+++ b/tests/regression/56-floats/01-base.c
@@ -6,20 +6,27 @@
 
 int main()
 {
-    double middle;
-    double a = 2.;
-    double b = 4.;
+    double x, a = 2., b = 3. + 1;
+    float y, c = 2.f, d = 3.f + 1;
 
-    assert(middle == 2.); // UNKNOWN!
+    assert(x == 2.);  // UNKNOWN!
+    assert(y == 2.f); // UNKNOWN!
 
     assert(a == 2.); // SUCCESS!
     assert(a < 10.); // SUCCESS!
     assert(a > 10.); // FAIL!
 
-    middle = (a + b) / 2.; // naive way of computing the middle
+    assert(c == 2.f); // SUCCESS!
+    assert(c < 10.f); // SUCCESS!
+    assert(c > 10.f); // FAIL!
 
-    assert(middle == 3.); // SUCCESS!
+    x = (a + b) / 2.;  // naive way of computing the middle
+    y = (c + d) / 2.; // naive way of computing the middle
 
-    assert(-97. == middle - 100.);
+    assert(x == 3.);  // SUCCESS!
+    assert(y == 3.f); // SUCCESS!
+
+    assert(-97. == x - 100.);
+    assert(-97.f == y - 100.f);
     return 0;
 }

--- a/tests/regression/56-floats/03-infinity_or_nan.c
+++ b/tests/regression/56-floats/03-infinity_or_nan.c
@@ -4,7 +4,11 @@
 void main()
 {
     double data;
-    
+    float data2;
+
     double result1 = data + 1.0; // WARN: Could be +/-infinity or Nan
-    double result2 = data / 0.; // WARN: Could be +/-infinity or Nan
+    double result2 = data / 0.;  // WARN: Could be +/-infinity or Nan
+
+    double result3 = data2 + 1.0f; // WARN: Could be +/-infinity or Nan
+    double result4 = data2 / 0.f;  // WARN: Could be +/-infinity or Nan
 }

--- a/tests/regression/56-floats/04-casts.c
+++ b/tests/regression/56-floats/04-casts.c
@@ -13,14 +13,28 @@
 
 int main()
 {
-    // Casts from double into different variants of ints
-    assert((int)0.0);      // FAIL!
-    assert((long)0.0);     // FAIL!
-    assert((unsigned)0.0); // FAIL!
+    int rnd;
 
-    assert((unsigned)1.0); // SUCCESS!
-    assert((long)2.0);     // SUCCESS!
-    assert((int)3.0);      // SUCCESS!
+    double value;
+    float value2;
+    int i;
+    long l;
+    unsigned u;
+
+    // Casts from double into different variants of ints
+    assert((int)0.0);       // FAIL!
+    assert((long)0.0);      // FAIL!
+    assert((unsigned)0.0);  // FAIL!
+    assert((int)0.0f);      // FAIL!
+    assert((long)0.0f);     // FAIL!
+    assert((unsigned)0.0f); // FAIL!
+
+    assert((unsigned)1.0);  // SUCCESS!
+    assert((long)2.0);      // SUCCESS!
+    assert((int)3.0);       // SUCCESS!
+    assert((unsigned)1.0f); // SUCCESS!
+    assert((long)2.0f);     // SUCCESS!
+    assert((int)3.0f);      // SUCCESS!
 
     // Cast from int into double
     assert((double)0);  // FAIL!
@@ -31,28 +45,39 @@ int main()
     assert((double)2l); // SUCCESS!
     assert((double)3);  // SUCCESS!
 
+    assert((float)0);  // FAIL!
+    assert((float)0l); // FAIL!
+    assert((float)0u); // FAIL!
+
+    assert((float)1u); // SUCCESS!
+    assert((float)2l); // SUCCESS!
+    assert((float)3);  // SUCCESS!
+
     // cast with ranges
-    int rnd;
-
-    double value;
-    int i;
-    long l;
-    unsigned u;
-
     RANGE(i, -5, 5);
     value = (double)i;
-    assert(-5. <= value && value <= 5.); // SUCCESS!
+    assert(-5. <= value && value <= 5.f); // SUCCESS!
+    value2 = (float)i;
+    assert(-5.f <= value2 && value2 <= 5.); // SUCCESS!
 
     RANGE(l, 10, 20);
     value = l;
-    assert(10. <= value && value <= 20.); // SUCCESS!
+    assert(10.f <= value && value <= 20.); // SUCCESS!
+    value2 = l;
+    assert(10. <= value2 && value2 <= 20.f); // SUCCESS!
 
     RANGE(u, 100, 1000);
     value = u;
     assert(value > 1.); // SUCCESS!
+    value2 = u;
+    assert(value2 > 1.f); // SUCCESS!
 
-    RANGE(value, -10., 10.);
+    RANGE(value, -10.f, 10.);
     i = (int)value;
+    assert(-10 <= i && i <= 10); // SUCCESS!
+
+    RANGE(value2, -10.f, 10.);
+    i = (int)value2;
     assert(-10 <= i && i <= 10); // SUCCESS!
 
     return 0;

--- a/tests/regression/56-floats/05-invariant.c
+++ b/tests/regression/56-floats/05-invariant.c
@@ -5,26 +5,20 @@
 int main()
 {
     double a;
-    int b;
+    float b;
+    int c, d;
 
     // make a definitly finite!
-    if (b)
+    if (c)
     {
         a = 100.;
+        b = 100.;
     }
     else
     {
         a = -100.;
+        b = -100.;
     };
-
-    if (b != 1)
-    {
-        assert(b != 1); // SUCCESS!
-    }
-    else
-    {
-        assert(b == 1); // SUCCESS!
-    }
 
     if (a != 1.)
     {
@@ -37,52 +31,63 @@ int main()
         assert(a == 1.); // SUCCESS!
     }
 
-    if ((int)a)
+    if (b == 1.f)
     {
-        assert(a != 0.); // UNKNOWN!
-    }
-    if (a) // here a explicit cast to (int) should be inserted
-    {
-        assert(a != 0.); // UNKNOWN!
+        assert(b == 1.f); // SUCCESS!
     }
 
     if (a <= 5.)
     {
         assert(a <= 5.); // SUCCESS!
     }
+    if (b <= 5.f)
+    {
+        assert(b <= 5.f); // SUCCESS!
+    }
 
     if (a <= 5. && a >= -5.)
     {
         assert(a <= 5. && a >= -5.); // SUCCESS!
     }
+    if (b <= 5.f && b >= -5.f)
+    {
+        assert(b <= 5. && b >= -5.); // SUCCESS!
+    }
 
-    if (a + 5. < 10.)
+    if (a + 5.f < 10.f)
     {
         assert(a < 5.); // SUCCESS!
     }
+    if (b + 5.f < 10.f)
+    {
+        assert(b < 5.f); // SUCCESS!
+    }
 
-    if (a * 2. < 6.)
+    if (a * 2. < 6.f)
     {
         assert(a < 3.); // SUCCESS!
+    }
+    if (b * 2.f < 6.f)
+    {
+        assert(b < 3.f); // SUCCESS!
     }
 
     if (a / 3. > 10.)
     {
         assert(a > 30.); // SUCCESS!
     }
+    if (b / 3.f > 10.f)
+    {
+        assert(b > 30.); // SUCCESS!
+    }
 
-    if (((int)a) < 10)
+    if (a < 10)
     {
         assert(a < 10.); // SUCCESS!
     }
-
-    int c;
-
-    if (0.5 < (double)c)
+    if (b < 10)
     {
-        assert(0 < c);  // SUCCESS!
-        assert(1 < c);  // UNKNOWN!
-        assert(1 <= c); // SUCCESS!
+        assert(b < 10.f); // SUCCESS!
     }
 
     if (a > 1.)

--- a/unittest/cdomains/floatDomainTest.ml
+++ b/unittest/cdomains/floatDomainTest.ml
@@ -1,12 +1,19 @@
 open OUnit2
-open Round
+open FloatOps
 
 module FloatInterval =
 struct
-  module FI = FloatDomain.FloatInterval
+  module FI = FloatDomain.F64Interval
   module IT = IntDomain.IntDomTuple
 
-  let fmax = Float.max_float
+  let to_float = FloatOps.CDouble.to_float
+  let of_float = FloatOps.CDouble.of_float
+  let add = FloatOps.CDouble.add
+  let sub = FloatOps.CDouble.sub
+  let mul = FloatOps.CDouble.mul
+  let div = FloatOps.CDouble.div
+
+  let fmax =  Float.max_float
   let fmin = -. Float.max_float
   let fsmall = Float.min_float
 
@@ -27,6 +34,7 @@ struct
   let test_FI_nan _ = 
     assert_equal (FI.top ()) (FI.of_const Float.nan)
 
+
   let test_FI_add_specific _ =
     let (+) = FI.add in
     let (=) a b = assert_equal b a in
@@ -34,11 +42,11 @@ struct
       (FI.of_const (-. 0.)) = fi_zero;
       fi_zero + fi_one = fi_one;
       fi_neg_one + fi_one = fi_zero;
-      fi_one + (FI.of_const fmax) = None;
-      fi_neg_one + (FI.of_const fmin) = None;
+      fi_one + (FI.of_const fmax) = FI.top ();
+      fi_neg_one + (FI.of_const fmin) = FI.top ();
       fi_neg_one + (FI.of_const fmax) = (FI.of_interval ((Float.pred fmax), fmax));
       fi_one + (FI.of_const fmin) = (FI.of_interval (fmin, Float.succ fmin));
-      FI.top () + FI.top () = None;
+      FI.top () + FI.top () = FI.top ();
       (FI.of_const fmin) + (FI.of_const fmax) = fi_zero;
       (FI.of_const fsmall) + (FI.of_const fsmall) = FI.of_const (fsmall +. fsmall);
       (FI.of_const fsmall) + (FI.of_const 1.) = FI.of_interval (1., Float.succ (1. +. fsmall));
@@ -52,11 +60,11 @@ struct
     begin
       fi_zero - fi_one = fi_neg_one;
       fi_neg_one - fi_one = FI.of_const (-. 2.);
-      fi_one - (FI.of_const fmin) = None;
-      fi_neg_one - (FI.of_const fmax) = None;
+      fi_one - (FI.of_const fmin) = FI.top ();
+      fi_neg_one - (FI.of_const fmax) = FI.top ();
       (FI.of_const fmax) - fi_one = (FI.of_interval ((Float.pred fmax), fmax));
       (FI.of_const fmin) - fi_neg_one = (FI.of_interval (fmin, Float.succ fmin));
-      FI.top () - FI.top () = None;
+      FI.top () - FI.top () = FI.top ();
       (FI.of_const fmax) - (FI.of_const fmax) = fi_zero;
       (FI.of_const fsmall) - (FI.of_const fsmall) = fi_zero;
       (FI.of_const fsmall) - (FI.of_const 1.) = FI.of_interval (-. 1., Float.succ (-. 1.));
@@ -69,10 +77,10 @@ struct
     let (=) a b = assert_equal b a in
     begin
       fi_zero * fi_one = fi_zero;
-      (FI.of_const 2.) * (FI.of_const fmin) = None;
-      (FI.of_const 2.) * (FI.of_const fmax) = None;
+      (FI.of_const 2.) * (FI.of_const fmin) = FI.top ();
+      (FI.of_const 2.) * (FI.of_const fmax) = FI.top ();
       (FI.of_const fsmall) * (FI.of_const fmax) = FI.of_const (fsmall *. fmax);
-      FI.top () * FI.top () = None;
+      FI.top () * FI.top () = FI.top ();
       (FI.of_const fmax) * fi_zero = fi_zero;
       (FI.of_const fsmall) * fi_zero = fi_zero;
       (FI.of_const fsmall) * fi_one = FI.of_const fsmall;
@@ -88,11 +96,11 @@ struct
     let (=) a b = assert_equal b a in
     begin
       fi_zero / fi_one = fi_zero;
-      (FI.of_const 2.) / fi_zero = None;
-      fi_zero / fi_zero = None;
-      (FI.of_const fmax) / (FI.of_const fsmall) = None;
-      (FI.of_const fmin) / (FI.of_const fsmall) = None;
-      FI.top () / FI.top () = None;
+      (FI.of_const 2.) / fi_zero = FI.top ();
+      fi_zero / fi_zero = FI.top ();
+      (FI.of_const fmax) / (FI.of_const fsmall) = FI.top ();
+      (FI.of_const fmin) / (FI.of_const fsmall) = FI.top ();
+      FI.top () / FI.top () = FI.top ();
       fi_zero / fi_one = fi_zero;
       (FI.of_const fsmall) / fi_one = FI.of_const fsmall;
       (FI.of_const fsmall) / (FI.of_const fsmall) = fi_one;
@@ -100,7 +108,7 @@ struct
       (FI.of_const fmax) / fi_one = FI.of_const fmax;
       (FI.of_const 2.) / (FI.of_const 0.5) = (FI.of_const 4.);
       (FI.of_const 4.) / (FI.of_const 2.) = (FI.of_const 2.);
-      (FI.of_interval (-. 2., 3.)) / (FI.of_interval (-. 100., 20.)) = None;
+      (FI.of_interval (-. 2., 3.)) / (FI.of_interval (-. 100., 20.)) = FI.top ();
       (FI.of_interval (6., 10.)) / (FI.of_interval (2., 3.)) = (FI.of_interval (2., 5.));
 
       (FI.of_const 1.00000000000000111) / (FI.of_const 1.00000000000000111) = fi_one;
@@ -142,7 +150,7 @@ struct
 
   let test_FI_castf2i_specific _ =
     let cast ikind a b = 
-      OUnit2.assert_equal ~cmp:IT.equal ~printer:IT.show b (FI.cast_to ikind a) in
+      OUnit2.assert_equal ~cmp:IT.equal ~printer:IT.show b (FI.to_int ikind a) in
     begin
       GobConfig.set_bool "ana.int.interval" true;
       cast IInt (FI.of_interval (-2147483648.,2147483647.)) (IT.top_of IInt);
@@ -257,22 +265,28 @@ struct
   let test_FI_add =
     QCheck.Test.make ~name:"test_FI_add" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.add (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (add Up arg1 arg2)) result) && (FI.leq (FI.of_const (add Down arg1 arg2)) result))
+        (FI.leq (FI.of_const (Option.get (to_float (add Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (add Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
 
   let test_FI_sub =
     QCheck.Test.make ~name:"test_FI_sub" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.sub (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (sub Up arg1 arg2)) result) && (FI.leq (FI.of_const (sub Down arg1 arg2)) result))
+        (FI.leq (FI.of_const (Option.get (to_float (sub Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (sub Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
 
   let test_FI_mul =
     QCheck.Test.make ~name:"test_FI_mul" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.mul (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (mul Up arg1 arg2)) result) && (FI.leq (FI.of_const (mul Down arg1 arg2)) result))
+        (FI.leq (FI.of_const (Option.get (to_float (mul Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (mul Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
+
 
   let test_FI_div =
     QCheck.Test.make ~name:"test_FI_div" (QCheck.pair QCheck.float QCheck.float) (fun (arg1, arg2) ->
         let result = FI.div (FI.of_const arg1) (FI.of_const arg2) in
-        (FI.leq (FI.of_const (div Up arg1 arg2)) result) && (FI.leq (FI.of_const (div Down arg1 arg2)) result))
+        (FI.leq (FI.of_const (Option.get (to_float (div Up (of_float Nearest arg1) (of_float Nearest arg2))))) result) && 
+        (FI.leq (FI.of_const (Option.get (to_float (div Down (of_float Nearest arg1) (of_float Nearest arg2))))) result))
+
 
   let test () = [
     "test_FI_nan" >:: test_FI_nan;
@@ -305,9 +319,11 @@ struct
     ]
 end
 
+
 let test () = 
   "floatDomainTest" >:::
   [ 
     "float_interval" >::: FloatInterval.test ();
     "float_interval_qcheck" >::: FloatInterval.test_qcheck ();
   ]
+


### PR DESCRIPTION
This fixes multiple issues:
 - it reimplements ocaml round -> therefore we can get ride of the external dependency
 - it exposes c's `atof` to ocaml to make string parsing possible
 - all the operations are possible for floats and doubles and a uniform interface is provided for both
 - it would now also be fairly simple to "out-source" other functions to c like `sqrt`, `log`, `cos`, `sin` etc.
 - we now support at least the two float kinds Float and Double
 - adjusts the casting in forward evaluation as well as backwards (invariant) and also fixes some rounding issues in invariant generally
 - introduces yet another module layer to store the ftype information
 - extends the regression and unit tests to also test for floats

Builds on #9