### PR TITLE
Check long doubles support and add tests for them

### DIFF
--- a/src/cdomains/valueDomain.ml
+++ b/src/cdomains/valueDomain.ml
@@ -139,7 +139,7 @@ struct
     match t with
     | t when is_mutex_type t -> `Top
     | TInt (ik,_) -> `Int (ID.top_of ik)
-    | TFloat (FFloat | FDouble as fkind, _) -> `Float (FD.top_of fkind)
+    | TFloat (fkind, _) -> `Float (FD.top_of fkind)
     | TPtr _ -> `Address AD.top_ptr
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> init_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
@@ -155,7 +155,7 @@ struct
   let rec top_value (t: typ): t =
     match t with
     | TInt (ik,_) -> `Int (ID.(cast_to ik (top_of ik)))
-    | TFloat (FFloat | FDouble as fkind, _) -> `Float (FD.top_of fkind)
+    | TFloat (fkind, _) -> `Float (FD.top_of fkind)
     | TPtr _ -> `Address AD.top_ptr
     | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> top_value fd.ftype) ci)
     | TComp ({cstruct=false; _},_) -> `Union (Unions.top ())
@@ -183,7 +183,7 @@ struct
     let rec zero_init_value (t:typ): t =
       match t with
       | TInt (ikind, _) -> `Int (ID.of_int ikind BI.zero)
-      | TFloat (FFloat | FDouble as fkind, _) -> `Float (FD.of_const fkind 0.0)
+      | TFloat (fkind, _) -> `Float (FD.of_const fkind 0.0)
       | TPtr _ -> `Address AD.null_ptr
       | TComp ({cstruct=true; _} as ci,_) -> `Struct (Structs.create (fun fd -> zero_init_value fd.ftype) ci)
       | TComp ({cstruct=false; _} as ci,_) ->
@@ -375,7 +375,7 @@ struct
                 (match Structs.get x first with `Int x -> x | _ -> raise CastError)*)
               | _ -> log_top __POS__; ID.top_of ik
             ))
-        | TFloat (FFloat | FDouble as fkind,_) ->
+        | TFloat (fkind,_) ->
           (match v with
            |`Int ix ->  `Float (FD.of_int fkind ix)
            |`Float fx ->  `Float (FD.cast_to fkind fx)

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -1583,7 +1583,7 @@
           "title": "warn.float",
           "description": "float warnings",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "cast": {
           "title": "warn.cast",

--- a/tests/regression/57-floats/01-base.c
+++ b/tests/regression/57-floats/01-base.c
@@ -8,25 +8,34 @@ int main()
 {
     double x, a = 2., b = 3. + 1;
     float y, c = 2.f, d = 3.f + 1;
+    long double z, e = 2.l, f = 3.l + 1;
 
     assert(x == 2.);  // UNKNOWN!
     assert(y == 2.f); // UNKNOWN!
+    assert(z == 2.l); // UNKNOWN!
 
-    assert(a == 2.); // SUCCESS!
-    assert(a < 10.); // SUCCESS!
-    assert(a > 10.); // FAIL!
+    assert(a == 2.); // SUCCESS
+    assert(a < 10.); // SUCCESS
+    assert(a > 10.); // FAIL
 
-    assert(c == 2.f); // SUCCESS!
-    assert(c < 10.f); // SUCCESS!
-    assert(c > 10.f); // FAIL!
+    assert(c == 2.f); // SUCCESS
+    assert(c < 10.f); // SUCCESS
+    assert(c > 10.f); // FAIL
+
+    assert(e == 2.f); // SUCCESS
+    assert(e < 10.f); // SUCCESS
+    assert(e > 10.f); // FAIL
 
     x = (a + b) / 2.;  // naive way of computing the middle
     y = (c + d) / 2.; // naive way of computing the middle
+    z = (e + f) / 2.; // naive way of computing the middle
 
-    assert(x == 3.);  // SUCCESS!
-    assert(y == 3.f); // SUCCESS!
+    assert(x == 3.);  // SUCCESS
+    assert(y == 3.f); // SUCCESS
+    assert(z == 3.f); // SUCCESS
 
     assert(-97. == x - 100.);
     assert(-97.f == y - 100.f);
+    assert(-97.f == z - 100.f);
     return 0;
 }

--- a/tests/regression/57-floats/02-node_configuration.c
+++ b/tests/regression/57-floats/02-node_configuration.c
@@ -7,7 +7,7 @@ void test() __attribute__((goblint_precision("float-interval")));
 int main()
 {
     double a = 2.;
-    assert(a == 2.); // UNKNOWN!
+    assert(a == 2.); // UNKNOWN
     test();
     return 0;
 }
@@ -15,5 +15,5 @@ int main()
 void test()
 {
     double b = 2.;
-    assert(b == 2.); // SUCCESS!
+    assert(b == 2.); // SUCCESS
 }

--- a/tests/regression/57-floats/03-infinity_or_nan.c
+++ b/tests/regression/57-floats/03-infinity_or_nan.c
@@ -1,14 +1,22 @@
-// PARAM: --enable ana.float.interval --enable warn.float
-#include <stdio.h>
+// PARAM: --enable ana.float.interval
+#include <float.h>
 
 void main()
 {
     double data;
     float data2;
+    long double data3;
 
     double result1 = data + 1.0; // WARN: Could be +/-infinity or Nan
     double result2 = data / 0.;  // WARN: Could be +/-infinity or Nan
 
     double result3 = data2 + 1.0f; // WARN: Could be +/-infinity or Nan
     double result4 = data2 / 0.f;  // WARN: Could be +/-infinity or Nan
+
+    double result5 = data3 + 1.0l; // WARN: Could be +/-infinity or Nan
+    double result6 = data3 / 0.l;  // WARN: Could be +/-infinity or Nan
+
+    // even though it will likely fit into a long double, the following also
+    // gives a warning as our long doubles internally only have the precision of "normal" doubles
+    data3 = DBL_MAX + 1.l; // WARN: Could be +/-infinity or Nan
 }

--- a/tests/regression/57-floats/04-casts.c
+++ b/tests/regression/57-floats/04-casts.c
@@ -17,68 +17,93 @@ int main()
 
     double value;
     float value2;
+    long double value3;
     int i;
     long l;
     unsigned u;
 
-    // Casts from double into different variants of ints
-    assert((int)0.0);       // FAIL!
-    assert((long)0.0);      // FAIL!
-    assert((unsigned)0.0);  // FAIL!
-    assert((int)0.0f);      // FAIL!
-    assert((long)0.0f);     // FAIL!
-    assert((unsigned)0.0f); // FAIL!
+    // Casts from double/flout/long double into different variants of ints
+    assert((int)0.0);       // FAIL
+    assert((long)0.0);      // FAIL
+    assert((unsigned)0.0);  // FAIL
+    assert((int)0.0f);      // FAIL
+    assert((long)0.0f);     // FAIL
+    assert((unsigned)0.0f); // FAIL
+    assert((int)0.0l);      // FAIL
+    assert((long)0.0l);     // FAIL
+    assert((unsigned)0.0l); // FAIL
 
-    assert((unsigned)1.0);  // SUCCESS!
-    assert((long)2.0);      // SUCCESS!
-    assert((int)3.0);       // SUCCESS!
-    assert((unsigned)1.0f); // SUCCESS!
-    assert((long)2.0f);     // SUCCESS!
-    assert((int)3.0f);      // SUCCESS!
+    assert((unsigned)1.0);  // SUCCESS
+    assert((long)2.0);      // SUCCESS
+    assert((int)3.0);       // SUCCESS
+    assert((unsigned)1.0f); // SUCCESS
+    assert((long)2.0f);     // SUCCESS
+    assert((int)3.0f);      // SUCCESS
+    assert((unsigned)1.0l); // SUCCESS
+    assert((long)2.0l);     // SUCCESS
+    assert((int)3.0l);      // SUCCESS
 
-    // Cast from int into double
-    assert((double)0);  // FAIL!
-    assert((double)0l); // FAIL!
-    assert((double)0u); // FAIL!
+    // Cast from int into double/flaot/long double
+    assert((double)0);  // FAIL
+    assert((double)0l); // FAIL
+    assert((double)0u); // FAIL
 
-    assert((double)1u); // SUCCESS!
-    assert((double)2l); // SUCCESS!
-    assert((double)3);  // SUCCESS!
+    assert((double)1u); // SUCCESS
+    assert((double)2l); // SUCCESS
+    assert((double)3);  // SUCCESS
 
-    assert((float)0);  // FAIL!
-    assert((float)0l); // FAIL!
-    assert((float)0u); // FAIL!
+    assert((float)0);  // FAIL
+    assert((float)0l); // FAIL
+    assert((float)0u); // FAIL
 
-    assert((float)1u); // SUCCESS!
-    assert((float)2l); // SUCCESS!
-    assert((float)3);  // SUCCESS!
+    assert((float)1u); // SUCCESS
+    assert((float)2l); // SUCCESS
+    assert((float)3);  // SUCCESS
+
+    assert((long double)0);  // FAIL
+    assert((long double)0l); // FAIL
+    assert((long double)0u); // FAIL
+
+    assert((long double)1u); // SUCCESS
+    assert((long double)2l); // SUCCESS
+    assert((long double)3);  // SUCCESS
 
     // cast with ranges
     RANGE(i, -5, 5);
     value = (double)i;
-    assert(-5. <= value && value <= 5.f); // SUCCESS!
+    assert(-5. <= value && value <= 5.f); // SUCCESS
     value2 = (float)i;
-    assert(-5.f <= value2 && value2 <= 5.); // SUCCESS!
+    assert(-5.f <= value2 && value2 <= 5.); // SUCCESS
+    value3 = (long double)i;
+    assert(-5.f <= value3 && value3 <= 5.l); // SUCCESS
 
     RANGE(l, 10, 20);
     value = l;
-    assert(10.f <= value && value <= 20.); // SUCCESS!
+    assert(10.f <= value && value <= 20.); // SUCCESS
     value2 = l;
-    assert(10. <= value2 && value2 <= 20.f); // SUCCESS!
+    assert(10.l <= value2 && value2 <= 20.f); // SUCCESS
+    value3 = l;
+    assert(10. <= value2 && value2 <= 20.); // SUCCESS
 
     RANGE(u, 100, 1000);
     value = u;
-    assert(value > 1.); // SUCCESS!
+    assert(value > 1.); // SUCCESS
     value2 = u;
-    assert(value2 > 1.f); // SUCCESS!
+    assert(value2 > 1.f); // SUCCESS
+    value3 = u;
+    assert(value2 > 1.l); // SUCCESS
 
     RANGE(value, -10.f, 10.);
     i = (int)value;
-    assert(-10 <= i && i <= 10); // SUCCESS!
+    assert(-10 <= i && i <= 10); // SUCCESS
 
     RANGE(value2, -10.f, 10.);
     i = (int)value2;
-    assert(-10 <= i && i <= 10); // SUCCESS!
+    assert(-10 <= i && i <= 10); // SUCCESS
+
+    RANGE(value3, -10.l, 10.);
+    i = (int)value3;
+    assert(-10 <= i && i <= 10); // SUCCESS
 
     return 0;
 }

--- a/tests/regression/57-floats/05-invariant.c
+++ b/tests/regression/57-floats/05-invariant.c
@@ -6,93 +6,112 @@ int main()
 {
     double a;
     float b;
-    int c, d;
+    long double c;
+    int d;
 
     // make a definitly finite!
-    if (c)
+    if (d)
     {
         a = 100.;
         b = 100.;
+        c = 100.;
     }
     else
     {
         a = -100.;
         b = -100.;
+        c = -100.;
     };
 
     if (a != 1.)
     {
         // this would require a exclusion list etc.
-        assert(a != 1.); // UNKNOWN!
+        assert(a != 1.); // UNKNOWN
     }
 
     if (a == 1.)
     {
-        assert(a == 1.); // SUCCESS!
+        assert(a == 1.); // SUCCESS
     }
 
     if (b == 1.f)
     {
-        assert(b == 1.f); // SUCCESS!
+        assert(b == 1.f); // SUCCESS
     }
 
     if (a <= 5.)
     {
-        assert(a <= 5.); // SUCCESS!
+        assert(a <= 5.); // SUCCESS
     }
     if (b <= 5.f)
     {
-        assert(b <= 5.f); // SUCCESS!
+        assert(b <= 5.f); // SUCCESS
+    }
+    if (c <= 5.f)
+    {
+        assert(c <= 5.f); // SUCCESS
     }
 
     if (a <= 5. && a >= -5.)
     {
-        assert(a <= 5. && a >= -5.); // SUCCESS!
+        assert(a <= 5. && a >= -5.); // SUCCESS
     }
     if (b <= 5.f && b >= -5.f)
     {
-        assert(b <= 5. && b >= -5.); // SUCCESS!
+        assert(b <= 5. && b >= -5.); // SUCCESS
     }
 
     if (a + 5.f < 10.f)
     {
-        assert(a <= 5.); // SUCCESS!
+        assert(a <= 5.); // SUCCESS
     }
     if (b + 5.f < 10.f)
     {
-        assert(b <= 5.f); // SUCCESS!
+        assert(b <= 5.l); // SUCCESS
+    }
+    if (c + 5.f < 10.f)
+    {
+        assert(c <= 5.f); // SUCCESS
     }
 
     if (a * 2. < 6.f)
     {
-        assert(a <= 3.); // SUCCESS!
+        assert(a <= 3.); // SUCCESS
     }
     if (b * 2.f < 6.f)
     {
-        assert(b <= 3.f); // SUCCESS!
+        assert(b <= 3.f); // SUCCESS
+    }
+    if (c * 2. < 6.f)
+    {
+        assert(c <= 3.f); // SUCCESS
     }
 
     if (a / 3. > 10.)
     {
-        assert(a >= 30.); // SUCCESS!
+        assert(a >= 30.); // SUCCESS
     }
     if (b / 3.f > 10.f)
     {
-        assert(b >= 30); // SUCCESS!
+        assert(b >= 30); // SUCCESS
     }
 
     if (a < 10)
     {
-        assert(a < 10.); // SUCCESS!
+        assert(a < 10.); // SUCCESS
     }
     if (b < 10)
     {
-        assert(b < 10.f); // SUCCESS!
+        assert(b < 10.f); // SUCCESS
+    }
+    if (c < 10)
+    {
+        assert(c < 10.l); // SUCCESS
     }
 
     if (a > 1.)
     {
-        assert(a < 1.); // FAIL!
+        assert(a < 1.); // FAIL
         if (a < 1.)
         {
             assert(0); // NOWARN

--- a/tests/regression/57-floats/06-library_functions.c
+++ b/tests/regression/57-floats/06-library_functions.c
@@ -1,79 +1,80 @@
-// PARAM: --enable ana.float.interval --enable ana.int.interval --enable warn.float
+// PARAM: --enable ana.float.interval --enable ana.int.interval
 #include <assert.h>
 #include <math.h>
 #include <float.h>
 
-int main() {
+int main()
+{
     double dbl_min = 2.2250738585072014e-308;
     double inf = 1. / 0.;
     double nan = 0. / 0.;
 
     //__buitin_isfinite(x):
-    assert(__builtin_isfinite(1.0)); //SUCCESS!
-    assert(__builtin_isfinite(inf)); //UNKNOWN
-    assert(__builtin_isfinite(nan)); //UNKNOWN
+    assert(__builtin_isfinite(1.0)); // SUCCESS
+    assert(__builtin_isfinite(inf)); // UNKNOWN
+    assert(__builtin_isfinite(nan)); // UNKNOWN
 
     //__buitin_isinf(x):
-    assert(__builtin_isinf(1.0)); //FAIL!
-    assert(__builtin_isinf(inf)); //UNKNOWN
-    assert(__builtin_isinf(nan)); //UNKNOWN
+    assert(__builtin_isinf(1.0)); // FAIL
+    assert(__builtin_isinf(inf)); // UNKNOWN
+    assert(__builtin_isinf(nan)); // UNKNOWN
 
     //__buitin_isinf_sign(x):
-    assert(__builtin_isinf_sign(1.0)); //FAIL!
-    assert(__builtin_isinf_sign(inf)); //UNKNOWN
-    assert(__builtin_isinf_sign(- inf)); //UNKNOWN
-    assert(__builtin_isinf_sign(nan)); //UNKNOWN
+    assert(__builtin_isinf_sign(1.0));  // FAIL
+    assert(__builtin_isinf_sign(inf));  // UNKNOWN
+    assert(__builtin_isinf_sign(-inf)); // UNKNOWN
+    assert(__builtin_isinf_sign(nan));  // UNKNOWN
 
     //__buitin_isnan(x):
-    assert(__builtin_isnan(1.0)); //FAIL!
-    assert(__builtin_isnan(inf)); //UNKNOWN
-    assert(__builtin_isnan(nan)); //UNKNOWN
+    assert(__builtin_isnan(1.0)); // FAIL
+    assert(__builtin_isnan(inf)); // UNKNOWN
+    assert(__builtin_isnan(nan)); // UNKNOWN
 
     //__buitin_isnormal(x):
-    assert(__builtin_isnormal(dbl_min)); //SUCCESS!
-    assert(__builtin_isnormal(0.0)); //FAIL!
-    assert(__builtin_isnormal(dbl_min / 2)); //FAIL!
-    assert(__builtin_isnormal(inf)); //UNKNOWN
-    assert(__builtin_isnormal(nan)); //UNKNOWN
+    assert(__builtin_isnormal(dbl_min));     // SUCCESS
+    assert(__builtin_isnormal(0.0));         // FAIL
+    assert(__builtin_isnormal(dbl_min / 2)); // FAIL
+    assert(__builtin_isnormal(inf));         // UNKNOWN
+    assert(__builtin_isnormal(nan));         // UNKNOWN
 
     //__buitin_signbit(x):
-    assert(__builtin_signbit(1.0)); //FAIL!
-    assert(__builtin_signbit(-1.0)); //SUCCESS!
-    assert(__builtin_signbit(0.0)); //UNKNOWN
-    assert(__builtin_signbit(inf)); //UNKNOWN
-    assert(__builtin_signbit(- inf)); //UNKNOWN
-    assert(__builtin_signbit(nan)); //UNKNOWN
+    assert(__builtin_signbit(1.0));  // FAIL
+    assert(__builtin_signbit(-1.0)); // SUCCESS
+    assert(__builtin_signbit(0.0));  // UNKNOWN
+    assert(__builtin_signbit(inf));  // UNKNOWN
+    assert(__builtin_signbit(-inf)); // UNKNOWN
+    assert(__builtin_signbit(nan));  // UNKNOWN
 
     double greater_than_pi = 3.142;
-    //acos(x):
-    assert((0. <= acos(0.1)) && (acos(0.1) <= greater_than_pi)); //SUCCESS!
-    assert(acos(1.) == 0.); //SUCCESS!
-    acos(2.0); //WARN: Domain error will occur: acos argument is outside of [-1., 1.]
+    // acos(x):
+    assert((0. <= acos(0.1)) && (acos(0.1) <= greater_than_pi)); // SUCCESS
+    assert(acos(1.) == 0.);                                      // SUCCESS
+    acos(2.0);                                                   // WARN: Domain error will occur: acos argument is outside of [-1., 1.]
 
-    //asin(x):
-    assert(((- greater_than_pi / 2.) <= asin(0.1)) && (asin(0.1) <= (greater_than_pi / 2.))); //SUCCESS!
-    assert(asin(0.) == 0.); //SUCCESS!
-    asin(2.0); //WARN: Domain error will occur: asin argument is outside of [-1., 1.]
+    // asin(x):
+    assert(((-greater_than_pi / 2.) <= asin(0.1)) && (asin(0.1) <= (greater_than_pi / 2.))); // SUCCESS
+    assert(asin(0.) == 0.);                                                                  // SUCCESS
+    asin(2.0);                                                                               // WARN: Domain error will occur: asin argument is outside of [-1., 1.]
 
-    //atan(x):
-    assert(((- greater_than_pi / 2.) <= atan(0.1)) && (atan(0.1) <= (greater_than_pi / 2.))); //SUCCESS!
-    assert(atan(0.) == 0.); //SUCCESS!
+    // atan(x):
+    assert(((-greater_than_pi / 2.) <= atan(0.1)) && (atan(0.1) <= (greater_than_pi / 2.))); // SUCCESS
+    assert(atan(0.) == 0.);                                                                  // SUCCESS
 
-    //atan2(y, x)
-    assert(((- greater_than_pi / 2.) <= atan2(0.1, 0.2)) && (atan2(0.1, 0.2) <= (greater_than_pi / 2.))); //SUCCESS!
+    // atan2(y, x)
+    assert(((-greater_than_pi / 2.) <= atan2(0.1, 0.2)) && (atan2(0.1, 0.2) <= (greater_than_pi / 2.))); // SUCCESS
 
-    //cos(x)
-    assert((-1. <= cos(0.1)) && (cos(0.1) <= 1.)); //SUCCESS!
-    assert(cos(0.) == 1.); //SUCCESS!
+    // cos(x)
+    assert((-1. <= cos(0.1)) && (cos(0.1) <= 1.)); // SUCCESS
+    assert(cos(0.) == 1.);                         // SUCCESS
 
-    //sin(x)
-    assert((-1. <= sin(0.1)) && (sin(0.1) <= 1.)); //SUCCESS!
-    assert(sin(0.) == 0.); //SUCCESS!
+    // sin(x)
+    assert((-1. <= sin(0.1)) && (sin(0.1) <= 1.)); // SUCCESS
+    assert(sin(0.) == 0.);                         // SUCCESS
 
-    //tan(x)
-    assert(tan(0.) == 0.); //SUCCESS!
+    // tan(x)
+    assert(tan(0.) == 0.); // SUCCESS
 
-    //unimplemented math.h function, should not invalidate globals:
-    j0(0.1); //NOWARN
-    ldexp(0.1, 1); //NOWARN
+    // unimplemented math.h function, should not invalidate globals:
+    j0(0.1);       // NOWARN
+    ldexp(0.1, 1); // NOWARN
 }

--- a/tests/regression/57-floats/07-equality.c
+++ b/tests/regression/57-floats/07-equality.c
@@ -1,9 +1,9 @@
-// PARAM: --enable ana.float.interval --enable warn.float
+// PARAM: --enable ana.float.interval
 
 void main()
 {
-    int check1 = (0.2 == 0.2); // WARN
-    int check2 = (0.2 != 0.3); // WARN
+    int check1 = (0.2f == 0.2); // WARN
+    int check2 = (0.2 != 0.3l); // WARN
 
     // Not all integers that are this big are representable in doubles anymore...
     double high_value = 179769313486231568384.0;

--- a/tests/regression/57-floats/08-bit_casts.c
+++ b/tests/regression/57-floats/08-bit_casts.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.float.interval --enable warn.float
+// PARAM: --enable ana.float.interval
 
 typedef union
 {

--- a/tests/regression/57-floats/09-svcomp_float_req_bl_1252b.c
+++ b/tests/regression/57-floats/09-svcomp_float_req_bl_1252b.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.float.interval --enable warn.float
+// PARAM: --enable ana.float.interval
 
 typedef int __int32_t;
 typedef unsigned int __uint32_t;


### PR DESCRIPTION
This extends the regression tests with some long double values and also introduces necessary features to support them (with double precision). This also removes all `!` after `SUCCESS` or `FAIL` and enables float warnings by default.