### PR TITLE
fix wording of Warning for Domain Error and add -f, -l trig. functions

### DIFF
--- a/src/analyses/libraryFunctions.ml
+++ b/src/analyses/libraryFunctions.ml
@@ -70,18 +70,32 @@ let math_descs_list: (string * LibraryDesc.t) list = LibraryDsl.[
     ("__builtin_signbit", special [__ "x" []] @@ fun x -> Math { fun_args = (Signbit x) });
     ("__builtin_acos", special [__ "x" []] @@ fun x -> Math { fun_args = (Acos x) });
     ("acos", special [__ "x" []] @@ fun x -> Math { fun_args = (Acos x) });
+    ("acosf", special [__ "x" []] @@ fun x -> Math { fun_args = (Acos x) });
+    ("acosl", special [__ "x" []] @@ fun x -> Math { fun_args = (Acos x) });
     ("__builtin_asin", special [__ "x" []] @@ fun x -> Math { fun_args = (Asin x) });
     ("asin", special [__ "x" []] @@ fun x -> Math { fun_args = (Asin x) });
+    ("asinf", special [__ "x" []] @@ fun x -> Math { fun_args = (Asin x) });
+    ("asinl", special [__ "x" []] @@ fun x -> Math { fun_args = (Asin x) });
     ("__builtin_atan", special [__ "x" []] @@ fun x -> Math { fun_args = (Atan x) });
     ("atan", special [__ "x" []] @@ fun x -> Math { fun_args = (Atan x) });
+    ("atanf", special [__ "x" []] @@ fun x -> Math { fun_args = (Atan x) });
+    ("atanl", special [__ "x" []] @@ fun x -> Math { fun_args = (Atan x) });
     ("__builtin_atan2", special [__ "y" []; __ "x" []] @@ fun y x -> Math { fun_args = (Atan2 (y, x)) });
     ("atan2", special [__ "y" []; __ "x" []] @@ fun y x -> Math { fun_args = (Atan2 (y, x)) });
+    ("atan2l", special [__ "y" []; __ "x" []] @@ fun y x -> Math { fun_args = (Atan2 (y, x)) });
+    ("atan2f", special [__ "y" []; __ "x" []] @@ fun y x -> Math { fun_args = (Atan2 (y, x)) });
     ("__builtin_cos", special [__ "x" []] @@ fun x -> Math { fun_args = (Cos x) });
     ("cos", special [__ "x" []] @@ fun x -> Math { fun_args = (Cos x) });
+    ("cosf", special [__ "x" []] @@ fun x -> Math { fun_args = (Cos x) });
+    ("cosl", special [__ "x" []] @@ fun x -> Math { fun_args = (Cos x) });
     ("__builtin_sin", special [__ "x" []] @@ fun x -> Math { fun_args = (Sin x) });
     ("sin", special [__ "x" []] @@ fun x -> Math { fun_args = (Sin x) });
+    ("sinf", special [__ "x" []] @@ fun x -> Math { fun_args = (Sin x) });
+    ("sinl", special [__ "x" []] @@ fun x -> Math { fun_args = (Sin x) });
     ("__builtin_tan", special [__ "x" []] @@ fun x -> Math { fun_args = (Tan x) });
     ("tan", special [__ "x" []] @@ fun x -> Math { fun_args = (Tan x) });
+    ("tanf", special [__ "x" []] @@ fun x -> Math { fun_args = (Tan x) });
+    ("tanl", special [__ "x" []] @@ fun x -> Math { fun_args = (Tan x) });
   ]
 
 (* TODO: allow selecting which lists to use *)

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -390,14 +390,14 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
     | (l, h) when l = h && l = Float_t.of_float Nearest 1. -> of_const 0. (*acos(1) = 0*)
     | (l, h) -> 
       if l < (Float_t.of_float Down (-.1.)) || h > (Float_t.of_float Up 1.) then
-        Messages.warn ~category:Messages.Category.Float "Domain error will occur: acos argument is outside of [-1., 1.]";
+        Messages.warn ~category:Messages.Category.Float "Domain error might occur: acos argument might be outside of [-1., 1.]";
       of_interval (0., (overapprox_pi)) (**could be more exact *)
 
   let eval_asin = function
     | (l, h) when l = h && l = Float_t.zero -> of_const 0. (*asin(0) = 0*)
     | (l, h) -> 
       if l < (Float_t.of_float Down (-.1.)) || h > (Float_t.of_float Up 1.) then
-        Messages.warn ~category:Messages.Category.Float "Domain error will occur: asin argument is outside of [-1., 1.]";
+        Messages.warn ~category:Messages.Category.Float "Domain error might occur: asin argument might be outside of [-1., 1.]";
       div (of_interval ((-. overapprox_pi), overapprox_pi)) (of_const 2.) (**could be more exact *)
 
   let eval_atan = function

--- a/tests/regression/57-floats/06-library_functions.c
+++ b/tests/regression/57-floats/06-library_functions.c
@@ -49,12 +49,12 @@ int main()
     // acos(x):
     assert((0. <= acos(0.1)) && (acos(0.1) <= greater_than_pi)); // SUCCESS
     assert(acos(1.) == 0.);                                      // SUCCESS
-    acos(2.0);                                                   // WARN: Domain error will occur: acos argument is outside of [-1., 1.]
+    acos(2.0);                                                   // WARN: Domain error might occur: acos argument might be outside of [-1., 1.]
 
     // asin(x):
     assert(((-greater_than_pi / 2.) <= asin(0.1)) && (asin(0.1) <= (greater_than_pi / 2.))); // SUCCESS
     assert(asin(0.) == 0.);                                                                  // SUCCESS
-    asin(2.0);                                                                               // WARN: Domain error will occur: asin argument is outside of [-1., 1.]
+    asin(2.0);                                                                               // WARN: Domain error might occur: asin argument might be outside of [-1., 1.]
 
     // atan(x):
     assert(((-greater_than_pi / 2.) <= atan(0.1)) && (atan(0.1) <= (greater_than_pi / 2.))); // SUCCESS


### PR DESCRIPTION
- changed "Domain error _will_ occur" -> "Domain error _might_ occur"
- added -l and -f trigonometric functions. these also exist for **all** the `__builtin_*` functions, at least for gcc (yes, there is even something like "`__builtin_signbitf`"). But I decided against adding these, as I did not want to clutter the `math_descs_list` in `libraryFunctions.ml` and I assumed that if someone uses the -l/-f functions they would probably not use them for the builtins...