### PR TITLE
fix 'Cilfacade.get_ikind: non-integer type double'

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -695,7 +695,7 @@ struct
     in
     let r =
     match exp with
-    | BinOp (op,arg1,arg2,_) -> binop op arg1 arg2
+    | BinOp (op,arg1,arg2,_) when Cil.isIntegralType (Cilfacade.typeOf exp) -> binop op arg1 arg2
     | _ -> eval_next ()
     in
     if M.tracing then M.traceu "evalint" "base eval_rv_ask_mustbeequal %a -> %a\n" d_exp exp VD.pretty r;

--- a/tests/regression/57-floats/12-subtraction_assignmen.c
+++ b/tests/regression/57-floats/12-subtraction_assignmen.c
@@ -1,0 +1,11 @@
+//PARAM: --enable ana.float.interval
+
+//previously failed in line 7 with "exception Invalid_argument("Cilfacade.get_ikind: non-integer type double ")" 
+//(same error as in sv-comp: float-newlib/float_req_bl_0220a.c)
+int main() {
+  double z;
+
+  z = 1 - 1.0;
+
+  assert(z == 0.); // SUCCESS
+}


### PR DESCRIPTION
I am not 100% sure if that makes sense, but it should fix (at least part of) the error and does not break any of the regression tests
Problem was that `Cilfacade.get_ikind exp` was called on floating-point exps in `binop op arg1 arg2`