### PR TITLE
Wrap get_ikind in try except to avoid crashing on invalid branching types

### DIFF
--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -254,10 +254,11 @@ struct
     in
     (* The main function! *)
     match a1,a2 with
-    (* For the integer values, we apply the domain operator *)
+    (* For the integer values, we apply the int domain operator *)
     | `Int v1, `Int v2 ->
       let result_ik = Cilfacade.get_ikind t in
       `Int (ID.cast_to result_ik (binop_ID result_ik op v1 v2))
+    (* For the float values, we apply the float domain operators *)
     | `Float v1, `Float v2 when is_int_returning_binop_FD op ->
       let result_ik = Cilfacade.get_ikind t in
       `Int (ID.cast_to result_ik (int_returning_binop_FD op v1 v2))
@@ -694,9 +695,9 @@ struct
       | _ -> eval_next ()
     in
     let r =
-    match exp with
-    | BinOp (op,arg1,arg2,_) when Cil.isIntegralType (Cilfacade.typeOf exp) -> binop op arg1 arg2
-    | _ -> eval_next ()
+      match exp with
+      | BinOp (op,arg1,arg2,_) when Cil.isIntegralType (Cilfacade.typeOf exp) -> binop op arg1 arg2
+      | _ -> eval_next ()
     in
     if M.tracing then M.traceu "evalint" "base eval_rv_ask_mustbeequal %a -> %a\n" d_exp exp VD.pretty r;
     r
@@ -2063,8 +2064,8 @@ struct
         | _ -> false
       in
       let itv = (* int abstraction for tv *)
-        (* when using floats without explicit cast, we can actually get a non-integer type -> this produces a warning *)
-        let ik = Cilfacade.get_ikind_exp exp in
+        (* when using floats without explicit cast, we can actually get a non-integer type *)
+        let ik = try Cilfacade.get_ikind_exp exp with Invalid_argument _ -> IInt in
         if not tv || is_cmp exp then (* false is 0, but true can be anything that is not 0, except for comparisons which yield 1 *)
           ID.of_bool ik tv (* this will give 1 for true which is only ok for comparisons *)
         else

--- a/src/util/cilfacade.ml
+++ b/src/util/cilfacade.ml
@@ -328,9 +328,7 @@ let get_fkind t =
   (* important to unroll the type here, otherwise problems with typedefs *)
   match Cil.unrollType t with
   | TFloat (fk,_) -> fk
-  | _ ->
-    Messages.warn "Something that we expected to be a float type has a different type, assuming it is an FDouble";
-    Cil.FDouble
+  | _ -> invalid_arg ("Cilfacade.get_fkind: non-float type " ^ CilType.Typ.show t)
 
 let ptrdiff_ikind () = get_ikind !ptrdiffType
 

--- a/tests/regression/57-floats/12-subtraction_assignmen.c
+++ b/tests/regression/57-floats/12-subtraction_assignmen.c
@@ -1,11 +1,20 @@
-//PARAM: --enable ana.float.interval
+// PARAM: --enable ana.float.interval
 
-//previously failed in line 7 with "exception Invalid_argument("Cilfacade.get_ikind: non-integer type double ")" 
+// previously failed in line 7 with "exception Invalid_argument("Cilfacade.get_ikind: non-integer type double ")"
 //(same error as in sv-comp: float-newlib/float_req_bl_0220a.c)
-int main() {
+// similar error also occured in the additional examples when branching on a float argument
+int main()
+{
   double z;
 
   z = 1 - 1.0;
 
   assert(z == 0.); // SUCCESS
+
+  if (0.)
+    ;
+
+  if (0 == (0. + 1.))
+    ;
+  assert(0); // FAIL
 }


### PR DESCRIPTION
This comes as an afterthought to #37 and guards the potentially invalid `get_ikind` call within a `try except`. This is required as the behaviour of `get_ikind` changed from only throwing a warning and returning `IInt` as default to raising an exception in those cases.
This also changes the behaviour of `get_fkind` to mimic that.