### PR TITLE
Option to allow better abstractions of functions with c-stubs

### DIFF
--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -443,13 +443,13 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
   let eval_cos_cfun l h =
     let (l', l'', h', h'') = trig_helper l h in
     if (Float_t.sub Up h' l') <= (Float_t.of_float Down 0.5) && (h'' <= Float_t.of_float Up 0.5) && (h'' >= l'') then
-      Interval (Float_t.sin Down h, Float_t.sin Up l)
+      Interval (Float_t.cos Down h, Float_t.cos Up l)
     else if (Float_t.sub Up h' l') <= (Float_t.of_float Down 0.5) && (l'' >= Float_t.of_float Down 0.5) && (h'' >= l'') then
-      Interval (Float_t.sin Down l, Float_t.sin Up h)
-    else if (Float_t.sub Up h' l') <= (Float_t.of_float Down 1.) && (l'' >= h'') then
-      Interval (Float_t.of_float Down (-.1.), max (Float_t.sin Up l) (Float_t.sin Up h))
+      Interval (Float_t.cos Down l, Float_t.cos Up h)
+    else if (Float_t.sub Up h' l') <= (Float_t.of_float Down 1.) && (l'' <= h'') then
+      Interval (Float_t.of_float Down (-.1.), max (Float_t.cos Up l) (Float_t.cos Up h))
     else if (Float_t.sub Up h' l') <= (Float_t.of_float Down 1.) && (l'' >= Float_t.of_float Down 0.5) && (h'' >= l'' || h'' <= Float_t.of_float Down 0.5) then
-      Interval (min (Float_t.sin Down l) (Float_t.sin Down h), Float_t.of_float Up 1.)
+      Interval (min (Float_t.cos Down l) (Float_t.cos Down h), Float_t.of_float Up 1.)
     else
     of_interval (-. 1., 1.)
 
@@ -471,7 +471,7 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
     if (Float_t.sub Up h' l') <= (Float_t.of_float Down 0.5) 
       && Bool.not ((l'' <= Float_t.of_float Up 0.25) && (h'' >= Float_t.of_float Down 0.25)) 
       && Bool.not ((l'' <= Float_t.of_float Up 0.75) && (h'' >= Float_t.of_float Down 0.75)) then
-        norm @@ Interval (Float_t.tan Down l, Float_t.tan Up h)
+        Interval (Float_t.tan Down l, Float_t.tan Up h)
     else
       top ()
 

--- a/src/cdomains/floatDomain.ml
+++ b/src/cdomains/floatDomain.ml
@@ -421,25 +421,31 @@ module FloatIntervalImpl(Float_t : CFloatType) = struct
 
   let eval_acos = function
     | (l, h) when l = h && l = Float_t.of_float Nearest 1. -> of_const 0. (*acos(1) = 0*)
-    | (l, h) ->
-      if l < (Float_t.of_float Down (-.1.)) || h > (Float_t.of_float Up 1.) then
-        Messages.warn ~category:Messages.Category.Float "Domain error might occur: acos argument might be outside of [-1., 1.]";
-      of_interval (0., (overapprox_pi)) (**could be more exact *)
+    | (l, h) when l < (Float_t.of_float Down (-.1.)) || h > (Float_t.of_float Up 1.) ->
+      Messages.warn ~category:Messages.Category.Float "Domain error might occur: acos argument might be outside of [-1., 1.]";
+      of_interval (0., (overapprox_pi))
+    | (l, h) when GobConfig.get_bool "ana.float.math_funeval" ->
+      Interval (Float_t.acos Down h, Float_t.acos Up l) (** acos is monotonic decreasing in [-1, 1]*)
+    | _ -> of_interval (0., (overapprox_pi))
 
   let eval_asin = function
     | (l, h) when l = h && l = Float_t.zero -> of_const 0. (*asin(0) = 0*)
-    | (l, h) ->
-      if l < (Float_t.of_float Down (-.1.)) || h > (Float_t.of_float Up 1.) then
-        Messages.warn ~category:Messages.Category.Float "Domain error might occur: asin argument might be outside of [-1., 1.]";
-      div (of_interval ((-. overapprox_pi), overapprox_pi)) (of_const 2.) (**could be more exact *)
+    | (l, h) when l < (Float_t.of_float Down (-.1.)) || h > (Float_t.of_float Up 1.) ->
+      Messages.warn ~category:Messages.Category.Float "Domain error might occur: asin argument might be outside of [-1., 1.]";
+      div (of_interval ((-. overapprox_pi), overapprox_pi)) (of_const 2.)
+    | (l, h) when GobConfig.get_bool "ana.float.math_funeval" ->
+      Interval (Float_t.asin Down l, Float_t.asin Up h) (** asin is monotonic increasing in [-1, 1]*)
+    | _ -> div (of_interval ((-. overapprox_pi), overapprox_pi)) (of_const 2.)
 
   let eval_atan = function
     | (l, h) when l = h && l = Float_t.zero -> of_const 0. (*atan(0) = 0*)
-    | _ -> div (of_interval ((-. overapprox_pi), overapprox_pi)) (of_const 2.) (**could be more exact *)
+    | (l, h) when GobConfig.get_bool "ana.float.math_funeval" ->
+      Interval (Float_t.atan Down l, Float_t.atan Up h) (** atan is monotonic increasing*)
+    | _ -> div (of_interval ((-. overapprox_pi), overapprox_pi)) (of_const 2.)
 
   let eval_cos = function
     | (l, h) when l = h && l = Float_t.zero -> of_const 1. (*cos(0) = 1*)
-    | _ -> of_interval (-. 1., 1.) (**could be exact for intervals where l=h, or even for Interval intervals *)
+    | _ -> of_interval (-. 1., 1.) (**could be exact for intervals where l=h, or even for some intervals *)
 
   let eval_sin = function
     | (l, h) when l = h && l = Float_t.zero -> of_const 0. (*sin(0) = 0*)

--- a/src/cdomains/floatOps/floatOps.ml
+++ b/src/cdomains/floatOps/floatOps.ml
@@ -33,6 +33,11 @@ module type CFloatType = sig
   val sub: round_mode -> t -> t -> t
   val mul: round_mode -> t -> t -> t
   val div: round_mode -> t -> t -> t
+
+  val acos: round_mode -> t -> t
+  val asin: round_mode -> t -> t
+  val atan: round_mode -> t -> t
+
   val atof: round_mode -> string -> t
 end
 
@@ -71,6 +76,10 @@ module CDouble = struct
   external mul: round_mode -> t -> t -> t = "mul_double"
   external div: round_mode -> t -> t -> t = "div_double"
 
+  external acos: round_mode -> t -> t = "acos_double"
+  external asin: round_mode -> t -> t = "asin_double"
+  external atan: round_mode -> t -> t = "atan_double"
+
   external atof: round_mode -> string -> t = "atof_double"
 end
 
@@ -101,6 +110,10 @@ module CFloat = struct
   external sub: round_mode -> t -> t -> t = "sub_float"
   external mul: round_mode -> t -> t -> t = "mul_float"
   external div: round_mode -> t -> t -> t = "div_float"
+
+  external acos: round_mode -> t -> t = "acos_float"
+  external asin: round_mode -> t -> t = "asin_float"
+  external atan: round_mode -> t -> t = "atan_float"
 
   external atof: round_mode -> string -> t = "atof_float"
 

--- a/src/cdomains/floatOps/floatOps.ml
+++ b/src/cdomains/floatOps/floatOps.ml
@@ -37,6 +37,9 @@ module type CFloatType = sig
   val acos: round_mode -> t -> t
   val asin: round_mode -> t -> t
   val atan: round_mode -> t -> t
+  val cos: round_mode -> t -> t
+  val sin: round_mode -> t -> t
+  val tan: round_mode -> t -> t
 
   val atof: round_mode -> string -> t
 end
@@ -79,6 +82,9 @@ module CDouble = struct
   external acos: round_mode -> t -> t = "acos_double"
   external asin: round_mode -> t -> t = "asin_double"
   external atan: round_mode -> t -> t = "atan_double"
+  external cos: round_mode -> t -> t = "cos_double"
+  external sin: round_mode -> t -> t = "sin_double"
+  external tan: round_mode -> t -> t = "tan_double"
 
   external atof: round_mode -> string -> t = "atof_double"
 end
@@ -114,6 +120,9 @@ module CFloat = struct
   external acos: round_mode -> t -> t = "acos_float"
   external asin: round_mode -> t -> t = "asin_float"
   external atan: round_mode -> t -> t = "atan_float"
+  external cos: round_mode -> t -> t = "cos_float"
+  external sin: round_mode -> t -> t = "sin_float"
+  external tan: round_mode -> t -> t = "tan_float"
 
   external atof: round_mode -> string -> t = "atof_float"
 

--- a/src/cdomains/floatOps/floatOps.mli
+++ b/src/cdomains/floatOps/floatOps.mli
@@ -37,6 +37,9 @@ module type CFloatType = sig
   val acos: round_mode -> t -> t
   val asin: round_mode -> t -> t
   val atan: round_mode -> t -> t
+  val cos: round_mode -> t -> t
+  val sin: round_mode -> t -> t
+  val tan: round_mode -> t -> t
   val atof: round_mode -> string -> t
 end
 

--- a/src/cdomains/floatOps/floatOps.mli
+++ b/src/cdomains/floatOps/floatOps.mli
@@ -34,6 +34,9 @@ module type CFloatType = sig
   val sub: round_mode -> t -> t -> t
   val mul: round_mode -> t -> t -> t
   val div: round_mode -> t -> t -> t
+  val acos: round_mode -> t -> t
+  val asin: round_mode -> t -> t
+  val atan: round_mode -> t -> t
   val atof: round_mode -> string -> t
 end
 

--- a/src/cdomains/floatOps/stubs.c
+++ b/src/cdomains/floatOps/stubs.c
@@ -47,6 +47,17 @@ static void change_round_mode(int mode)
         return caml_copy_double(r);                              \
     }
 
+#define UNARY_FUN(name, type)                                \
+    CAMLprim value name##_##type(value mode, value x)   \
+    {                                                            \
+        int old_roundingmode = fegetround();                     \
+        change_round_mode(Int_val(mode));                        \
+        volatile type r, x1 = Double_val(x); \
+        r = name(x1);                                            \
+        fesetround(old_roundingmode);                            \
+        return caml_copy_double(r);                              \
+    }
+
 BINARY_OP(add, double, +);
 BINARY_OP(add, float, +);
 BINARY_OP(sub, double, -);
@@ -55,6 +66,13 @@ BINARY_OP(mul, double, *);
 BINARY_OP(mul, float, *);
 BINARY_OP(div, double, /);
 BINARY_OP(div, float, /);
+
+UNARY_FUN(acos, double);
+UNARY_FUN(acos, float);
+UNARY_FUN(asin, float);
+UNARY_FUN(asin, double);
+UNARY_FUN(atan, float);
+UNARY_FUN(atan, double);
 
 CAMLprim value atof_double(value mode, value str)
 {

--- a/src/cdomains/floatOps/stubs.c
+++ b/src/cdomains/floatOps/stubs.c
@@ -73,6 +73,12 @@ UNARY_FUN(asin, float);
 UNARY_FUN(asin, double);
 UNARY_FUN(atan, float);
 UNARY_FUN(atan, double);
+UNARY_FUN(cos, double);
+UNARY_FUN(cos, float);
+UNARY_FUN(sin, float);
+UNARY_FUN(sin, double);
+UNARY_FUN(tan, float);
+UNARY_FUN(tan, double);
 
 CAMLprim value atof_double(value mode, value str)
 {

--- a/src/util/options.schema.json
+++ b/src/util/options.schema.json
@@ -416,6 +416,13 @@
                 "Use FloatDomain: (float * float) option.",
               "type": "boolean",
               "default": false
+            },
+            "math_funeval": {
+              "title": "ana.float.math_funeval",
+              "description":
+                "Allow evaluation of functions from math.h with c-stubs. Only sound, if the same math.h implementation is used for the programm that is also used in Goblint",
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/tests/regression/57-floats/14-math-funeval.c
+++ b/tests/regression/57-floats/14-math-funeval.c
@@ -1,4 +1,4 @@
-// PARAM: --enable ana.float.interval --enable ana.int.interval --enable ana.float.math_funeval
+// PARAM: --enable ana.float.interval --enable ana.float.math_funeval
 #include <assert.h>
 #include <math.h>
 #include <float.h>
@@ -6,14 +6,58 @@
 int main()
 {
     int x;
-    double d;
+    double s1, s2, c1, c2, sc1, sc2, t1, t2;
+    //s1: 0.5pi < [2.0, 7.5] < 2.5pi
+    //s2: 1.5pi < [5.0, 10.5] < 3.5pi
+    //c1: 0pi < [0.2, 6.1] < 2pi
+    //c2: pi < [3.3, 9.0] < 3pi
+    //sc1: 0.5pi < [2.0, 3.0] < pi
+    //sc2: 4.5pi < [14.5, 15.5] < 5pi
+    //t1: pi-0.1 < [3.1, 3.2] < pi+0.1
+    //t2: 6pi-0.1 < [18.8, 18.9] < 6pi+0.1
     if (x) {
-        d = -8.6;
+        s1 = 2.0;
+        s2 = 5.0;
+        c1 = 0.2;
+        c2 = 3.3;
+        sc1 = 2.0;
+        sc2 = 14.5;
+        t1 = 3.1;
+        t2 = 18.8;
     }
     else {
-        d = -6.7;
+        s1 = 7.5;
+        s2 = 10.5;
+        c1 = 6.1;
+        c2 = 9.0;
+        sc1 = 3.0;
+        sc2 = 15.5;
+        t1 = 3.2;
+        t2 = 18.9;
     }
-    assert(sin(d) < 0);
-    assert(sin(d) > -0.99);
-    assert(sin(d) < 0.99);
+    
+    //acos(x)
+    assert(1.4 < acos(0.1) && acos(0.1) < 1.5); // SUCCESS
+
+    //asin(x)
+    assert(0.6 < asin(0.6) && asin(0.6) < 0.7); // SUCCESS
+
+    //atan(x)
+    assert(0.7 < atan(1.) && atan(1.) < 0.8);   // SUCCESS
+
+    //cos(x)
+    assert(-1. <= cos(c1) && cos(c1) < 0.99);   // SUCCESS
+    assert(-0.99 < cos(c2) && cos(c2) <= 1.0);  // SUCCESS
+    assert(-0.99 < cos(sc1) && cos(sc1) < 0.);  // SUCCESS
+    assert(-0.99 < cos(sc2) && cos(sc2) < 0.);  // SUCCESS
+
+    //sin(x)
+    assert(-1. <= sin(s1) && sin(s1) < 0.99);   // SUCCESS
+    assert(-0.99 < sin(s2) && sin(s2) <= 1.);   // SUCCESS
+    assert(0. < sin(sc1) && sin(sc1) < 0.99);   // SUCCESS
+    assert(0. < sin(sc2) && sin(sc2) < 0.99);   // SUCCESS
+
+    //tan(x)
+    assert(-0.1 < tan(t1) && tan(t1) < 0.1 );   // SUCCESS
+    assert(-0.1 < tan(t2) && tan(t2) < 0.1 );   // SUCCESS
 }

--- a/tests/regression/57-floats/14-math-funeval.c
+++ b/tests/regression/57-floats/14-math-funeval.c
@@ -1,0 +1,19 @@
+// PARAM: --enable ana.float.interval --enable ana.int.interval --enable ana.float.math_funeval
+#include <assert.h>
+#include <math.h>
+#include <float.h>
+
+int main()
+{
+    int x;
+    double d;
+    if (x) {
+        d = -8.6;
+    }
+    else {
+        d = -6.7;
+    }
+    assert(sin(d) < 0);
+    assert(sin(d) > -0.99);
+    assert(sin(d) < 0.99);
+}


### PR DESCRIPTION
Adds the option 'ana.float.math_funeval' for acos, asin, atan, cos, sin, tan.
TODO:
- [ ] An explanation of why I think this is correct will be added
- [x] Tests will be added
- [ ] Possibly further abstractions for other important functions (pow, log, exp, ...)